### PR TITLE
Add /api and /api/.* routes to Kube Ingress

### DIFF
--- a/minikube/routes.yml
+++ b/minikube/routes.yml
@@ -31,6 +31,16 @@ spec:
             backend:
               serviceName: tb-http-transport
               servicePort: 8080
+          - path: /api
+            pathType: ImplementationSpecific
+            backend:
+              serviceName: tb-node
+              servicePort: 8080
+          - path: /api/.*
+            pathType: ImplementationSpecific
+            backend:
+              serviceName: tb-node
+              servicePort: 8080
           - path: /static/rulenode/.*
             backend:
               serviceName: tb-node

--- a/minikube/routes.yml
+++ b/minikube/routes.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tb-ingress
@@ -28,37 +28,60 @@ spec:
     - http:
         paths:
           - path: /api/v1/.*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: tb-http-transport
-              servicePort: 8080
+              service:
+                name: tb-http-transport
+                port:
+                  number: 8080
           - path: /api
             pathType: ImplementationSpecific
             backend:
-              serviceName: tb-node
-              servicePort: 8080
+              service:
+                name: tb-node
+                port:
+                  number: 8080
           - path: /api/.*
             pathType: ImplementationSpecific
             backend:
-              serviceName: tb-node
-              servicePort: 8080
+              service:
+                name: tb-node
+                port:
+                  number: 8080
           - path: /static/rulenode/.*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: tb-node
-              servicePort: 8080
+              service:
+                name: tb-node
+                port:
+                  number: 8080
           - path: /static/.*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: tb-web-ui
-              servicePort: 8080
+              service:
+                name: tb-web-ui
+                port:
+                  number: 8080
           - path: /index.html.*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: tb-web-ui
-              servicePort: 8080
+              service:
+                name: tb-web-ui
+                port:
+                  number: 8080
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: tb-web-ui
-              servicePort: 8080
+              service:
+                name: tb-web-ui
+                port:
+                  number: 8080
           - path: /.*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: tb-node
-              servicePort: 8080
+              service:
+                name: tb-node
+                port:
+                  number: 8080
 ---
+


### PR DESCRIPTION
By default, the Kubernetes ThingsBoard installation will whitepage on login, due to missing routes in the Ingress file. This PR addresses [this issue](https://github.com/thingsboard/thingsboard/issues/1715) in the main repo.