### PR TITLE
Simplify Zookeeper Startup script

### DIFF
--- a/aws/microservices/zookeeper.yml
+++ b/aws/microservices/zookeeper.yml
@@ -25,7 +25,7 @@ data:
     set -ex;
     mkdir -p "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR";
     echo $HOSTNAME| rev | cut -d "-" -f1 | rev > "$ZOO_DATA_DIR/myid"
-    /apache-zookeeper-3.5.7-bin/bin/zkServer.sh start-foreground /conf/zoo.cfg
+    zkServer.sh start-foreground /conf/zoo.cfg
   zoo.cfg: |+
     dataDir=/data
     dataLogDir=/datalog

--- a/azure/microservices/thirdparty.yml
+++ b/azure/microservices/thirdparty.yml
@@ -25,7 +25,7 @@ data:
     set -ex;
     mkdir -p "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR";
     echo $HOSTNAME| rev | cut -d "-" -f1 | rev > "$ZOO_DATA_DIR/myid"
-    /apache-zookeeper-3.5.7-bin/bin/zkServer.sh start-foreground /conf/zoo.cfg
+    zkServer.sh start-foreground /conf/zoo.cfg
   zoo.cfg: |+
     dataDir=/data
     dataLogDir=/datalog

--- a/gcp/microservices/thirdparty.yml
+++ b/gcp/microservices/thirdparty.yml
@@ -25,7 +25,7 @@ data:
     set -ex;
     mkdir -p "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR";
     echo $HOSTNAME| rev | cut -d "-" -f1 | rev > "$ZOO_DATA_DIR/myid"
-    /apache-zookeeper-3.5.7-bin/bin/zkServer.sh start-foreground /conf/zoo.cfg
+    zkServer.sh start-foreground /conf/zoo.cfg
   zoo.cfg: |+
     dataDir=/data
     dataLogDir=/datalog

--- a/minikube/thirdparty.yml
+++ b/minikube/thirdparty.yml
@@ -25,7 +25,7 @@ data:
     set -ex;
     mkdir -p "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR";
     echo $HOSTNAME| rev | cut -d "-" -f1 | rev > "$ZOO_DATA_DIR/myid"
-    /apache-zookeeper-3.5.7-bin/bin/zkServer.sh start-foreground /conf/zoo.cfg
+    zkServer.sh start-foreground /conf/zoo.cfg
   zoo.cfg: |+
     dataDir=/data
     dataLogDir=/datalog

--- a/openshift/thirdparty.yml
+++ b/openshift/thirdparty.yml
@@ -25,7 +25,7 @@ data:
     set -ex;
     mkdir -p "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR";
     echo $HOSTNAME| rev | cut -d "-" -f1 | rev > "$ZOO_DATA_DIR/myid"
-    /apache-zookeeper-3.5.7-bin/bin/zkServer.sh start-foreground /conf/zoo.cfg
+    zkServer.sh start-foreground /conf/zoo.cfg
   zoo.cfg: |+
     dataDir=/data
     dataLogDir=/datalog


### PR DESCRIPTION
Simplify Zookeeper startup script. Makes it easier to upgrade Zookeeper version from current version to for example 3.6.

Since the path to the Zookeeper bin folder is set in the $PATH variable, direct use zkServer.sh script.

Sample Path output version 3.6.3. Same is true for version 3.5.7.
```bash
echo $PATH
/usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/apache-zookeeper-3.6.3-bin/bin
```