### PR TITLE
setup timeout for initializedb job using helm chart values.

### DIFF
--- a/helm/thingsboard/templates/initializedb-job.yaml
+++ b/helm/thingsboard/templates/initializedb-job.yaml
@@ -30,7 +30,7 @@ spec:
         - name: check-db-ready
           image: postgres:{{ index .Values "postgresql-ha" "postgresqlImage" "tag" }}
           command: ['sh', '-c',
-            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }};
+            'until pg_isready -h {{ include "thingsboard.pgpoolservicename" . }} -p {{ index .Values "postgresql-ha" "pgpool" "containerPort" }} -t {{ .Values.initializedb.check.timeout }};
             do echo waiting for database; sleep 2; done;']
       containers:
       - name: init-db

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -300,3 +300,7 @@ kafka:
   zookeeper:
     persistence:
       enabled: false
+initializedb:
+  check:
+    # default value of the timeout for the pg_isready command
+    timeout: 3


### PR DESCRIPTION
I am deploying thingsboard into a kind cluster running locally in my laptop and the initialize database job takes a lot of time to complete just because checking the status of the database takes more than 3 seconds.
Being able to set up this timeout using values helped me to finally start the chart without further issues. I set up the default value for the timeout in the values to be backward compatible.

find out more details at: https://www.postgresql.org/docs/current/app-pg-isready.html#:~:text=The%20default%20is%203%20seconds.