### PR TITLE
fix http transport bind port for load-balancer

### DIFF
--- a/aws/microservices/transports/tb-http-transport.yml
+++ b/aws/microservices/transports/tb-http-transport.yml
@@ -108,6 +108,8 @@ spec:
               value: "true"
             - name: ZOOKEEPER_URL
               value: "zookeeper:2181"
+            - name: HTTP_BIND_PORT
+              value: "8080"
           envFrom:
             - configMapRef:
                 name: tb-kafka-config


### PR DESCRIPTION
The default port for HTTP-transport is 8081. 
However, in the load-balancer rules, livenessProbe and readinessProbe, the port is configured as 8080.