### PR TITLE
Delete the TRANSPORT_TYPE variable as unused

### DIFF
--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -75,8 +75,6 @@ spec:
             value: "{{ .Values.kafka.offsetsTopicReplicationFactor }}"
           - name: JS_EVALUATOR
             value: "remote"
-          - name: TRANSPORT_TYPE
-            value: "remote"
           - name: HTTP_LOG_CONTROLLER_ERROR_STACK_TRACE
             value: "false"
           - name: CACHE_TYPE

--- a/minikube/tb-node.yml
+++ b/minikube/tb-node.yml
@@ -68,8 +68,6 @@ spec:
           value: "tb-kafka:9092"
         - name: JS_EVALUATOR
           value: "remote"
-        - name: TRANSPORT_TYPE
-          value: "remote"
         - name: HTTP_LOG_CONTROLLER_ERROR_STACK_TRACE
           value: "false"
         - name: CACHE_TYPE

--- a/openshift/tb-node.yml
+++ b/openshift/tb-node.yml
@@ -68,8 +68,6 @@ spec:
           value: "tb-kafka:9092"
         - name: JS_EVALUATOR
           value: "remote"
-        - name: TRANSPORT_TYPE
-          value: "remote"
         - name: HTTP_LOG_CONTROLLER_ERROR_STACK_TRACE
           value: "false"
         - name: CACHE_TYPE


### PR DESCRIPTION
Remove the TRANSPORT_TYPE variable because it is not used in yml files. And this variable is not used in cloud deployment files.