### PR TITLE
Updates Chart dependencies and includes missing value for postgresql-ha.pgpool.containerPort

### DIFF
--- a/helm/thingsboard/Chart.yaml
+++ b/helm/thingsboard/Chart.yaml
@@ -24,15 +24,15 @@ icon: https://avatars.githubusercontent.com/u/24291394?s=200&v=4
 home: https://github.com/thingsboard/thingsboard-ce-k8s/
 dependencies:
   - name: postgresql-ha
-    version: 8.5.2
+    version: 9.1.1
     repository: https://charts.bitnami.com/bitnami
   - name: cassandra
-    version: 9.1.8
+    version: 9.2.2
     repository: https://charts.bitnami.com/bitnami
     condition: cassandra.enabled
   - name: kafka
-    version: 15.3.4
+    version: 17.2.3
     repository: https://charts.bitnami.com/bitnami
   - name: redis
-    version: 16.4.5
+    version: 16.11.2
     repository: https://charts.bitnami.com/bitnami

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -275,6 +275,7 @@ postgresql-ha:
     adminPassword: setplease
     replicaCount: 1
     useLoadBalancing: false
+    containerPort: 5432
   pgpoolImage:
     tag: 4
 


### PR DESCRIPTION
The Chart's dependencies were outdated, so the closest available version of each dependency is now set.

In the `initialized-job.yaml` template, the `posgresql-ha.pgpool.containerPort` values is used:
https://github.com/thingsboard/thingsboard-ce-k8s/blob/62795744c3b911774466a7125b52b69666fb5750/helm/thingsboard/templates/initializedb-job.yaml#L29-L34

However, this value is not defined in the default `values.yaml`, causing the Kubernetes Job to never be completed. This value is now included in order to fix this issue.