### PR TITLE
Added missing edge port in GCP yaml

### DIFF
--- a/gcp/microservices/tb-services.yml
+++ b/gcp/microservices/tb-services.yml
@@ -134,6 +134,8 @@ spec:
   ports:
     - port: 8080
       name: http
+    - port: 7070
+      name: edge
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/gcp/monolith/tb-node.yml
+++ b/gcp/monolith/tb-node.yml
@@ -156,3 +156,6 @@ spec:
   ports:
     - port: 8080
       name: http
+  ports:
+    - port: 7070
+      name: edge


### PR DESCRIPTION
With the yaml as it was, port 7070 was not exposed in the tb-node service.

Thingsboard Edge instances could not communicate with Thingsboard CE deployed that way.

Adding port 7070 to the service fixes the issue.