### PR TITLE
Updated version to 3.5.0

### DIFF
--- a/helm/thingsboard/Chart.yaml
+++ b/helm/thingsboard/Chart.yaml
@@ -18,21 +18,21 @@ apiVersion: v2
 name: thingsboard
 description: A Helm chart for Thingsboard
 type: application
-version: 0.1.1
+version: 0.1.3
 appVersion: 3.4.0
 icon: https://avatars.githubusercontent.com/u/24291394?s=200&v=4
 home: https://github.com/thingsboard/thingsboard-ce-k8s/
 dependencies:
   - name: postgresql-ha
     version: 8.5.2
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
   - name: cassandra
-    version: 9.1.8
+    version: 10.1.0
     repository: https://charts.bitnami.com/bitnami
     condition: cassandra.enabled
   - name: kafka
     version: 15.3.4
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
   - name: redis
     version: 16.4.5
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -17,7 +17,7 @@
 global:
   image:
     server: docker.io
-    tag: "3.4.0"
+    tag: "3.5.0"
     pullSecrets: []
     pullPolicy: Always
   jsonLogs: false
@@ -275,6 +275,7 @@ postgresql-ha:
     adminPassword: setplease
     replicaCount: 1
     useLoadBalancing: false
+    containerPort: 5432
   pgpoolImage:
     tag: 4
 


### PR DESCRIPTION
Updates Chart dependencies, and includes missing value for postgresql-ha.pgpool.containerPort and changed version to 3.5.0