### PR TITLE
Fix lb's public access

### DIFF
--- a/aws/microservices/receipts/coap-load-balancer.yml
+++ b/aws/microservices/receipts/coap-load-balancer.yml
@@ -7,6 +7,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: ThingsBoardClusterELB=ThingsBoardCoap
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local

--- a/aws/microservices/receipts/edge-load-balancer.yml
+++ b/aws/microservices/receipts/edge-load-balancer.yml
@@ -12,6 +12,7 @@ metadata:
     # OR comment/remove the following lines to disable TLS.
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: YOUR_GRPC_CERTIFICATE_ARN
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "7070"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local

--- a/aws/microservices/receipts/lwm2m-load-balancer.yml
+++ b/aws/microservices/receipts/lwm2m-load-balancer.yml
@@ -7,6 +7,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: ThingsBoardClusterELB=ThingsBoardLwM2M
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local

--- a/aws/microservices/receipts/mqtt-load-balancer.yml
+++ b/aws/microservices/receipts/mqtt-load-balancer.yml
@@ -8,6 +8,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: "stickiness.enabled=true,stickiness.type=source_ip"
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: ThingsBoardClusterELB=ThingsBoardMqtt
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local

--- a/aws/microservices/receipts/mqtts-load-balancer.yml
+++ b/aws/microservices/receipts/mqtts-load-balancer.yml
@@ -12,6 +12,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: YOUR_MQTTS_CERTIFICATE_ARN
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "mqtts"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local

--- a/aws/monolith/receipts/edge-load-balancer.yml
+++ b/aws/monolith/receipts/edge-load-balancer.yml
@@ -12,6 +12,7 @@ metadata:
     # OR comment/remove the following lines to disable TLS.
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: YOUR_GRPC_CERTIFICATE_ARN
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "7070"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local

--- a/aws/monolith/receipts/mqtt-load-balancer.yml
+++ b/aws/monolith/receipts/mqtt-load-balancer.yml
@@ -8,6 +8,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: "stickiness.enabled=true,stickiness.type=source_ip"
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: ThingsBoardClusterELB=ThingsBoardMqtt
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local

--- a/aws/monolith/receipts/mqtts-load-balancer.yml
+++ b/aws/monolith/receipts/mqtts-load-balancer.yml
@@ -12,6 +12,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: YOUR_MQTTS_CERTIFICATE_ARN
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "mqtts"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local

--- a/aws/monolith/receipts/udp-load-balancer.yml
+++ b/aws/monolith/receipts/udp-load-balancer.yml
@@ -7,6 +7,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: ThingsBoardClusterELB=ThingsBoardCoap
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local


### PR DESCRIPTION
Since [v2.2.0](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.2.0) release, the AWS Load balancer controller provisions an internal NLB by default.
The solution is to add the annotation "service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing" for load balancers.
[aws-load-balancer-controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/nlb/)