### PR TITLE
updated dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 *.zip
 *.tar.gz
 *.rar
+*.tgz
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/helm/thingsboard/Chart.lock
+++ b/helm/thingsboard/Chart.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: postgresql-ha
+  repository: https://charts.bitnami.com/bitnami
+  version: 12.3.7
+- name: cassandra
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.6.8
+- name: kafka
+  repository: https://charts.bitnami.com/bitnami
+  version: 26.6.2
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 18.6.1
+digest: sha256:65e0613b181a620ffa356bbfdd4fa897930c5e30ee48819042a1e7408a9ca50a
+generated: "2024-01-03T15:12:31.295756+01:00"

--- a/helm/thingsboard/Chart.yaml
+++ b/helm/thingsboard/Chart.yaml
@@ -24,15 +24,15 @@ icon: https://avatars.githubusercontent.com/u/24291394?s=200&v=4
 home: https://github.com/thingsboard/thingsboard-ce-k8s/
 dependencies:
   - name: postgresql-ha
-    version: 8.5.2
+    version: 12.3.7
     repository: https://charts.bitnami.com/bitnami
   - name: cassandra
-    version: 9.1.8
+    version: 10.6.8
     repository: https://charts.bitnami.com/bitnami
     condition: cassandra.enabled
   - name: kafka
-    version: 15.3.4
+    version: 26.6.2
     repository: https://charts.bitnami.com/bitnami
   - name: redis
-    version: 16.4.5
+    version: 18.6.1
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
postgresql-ha, cassandra, kafka, redis to obtainable versions.

Helm charts are broken without this fix.