### PR TITLE
Fix AWS mqtts-loadbalancer app selector

### DIFF
--- a/aws/microservices/receipts/mqtts-load-balancer.yml
+++ b/aws/microservices/receipts/mqtts-load-balancer.yml
@@ -17,7 +17,7 @@ spec:
   type: LoadBalancer
   externalTrafficPolicy: Local
   selector:
-    app: tb-node
+    app: tb-mqtt-transport
   ports:
     - port: 1883
       targetPort: 1883


### PR DESCRIPTION
Route load balancing to mqtt-transport instead of tb-node, according to [mqtt-load-balancer](https://github.com/thingsboard/thingsboard-ce-k8s/blob/master/aws/microservices/receipts/mqtt-load-balancer.yml)