### PR TITLE
Add metrics enabling variables to chart

### DIFF
--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -83,6 +83,12 @@ spec:
             value: "{{ .Release.Name }}-redis-master"
           - name: REDIS_PASSWORD
             value: "{{ .Values.redis.auth.password }}"
+          {{- if eq .Values.metrics.enabled true }}
+          - name: METRICS_ENABLED
+            value: "{{ .Values.metrics.enabled }}"
+          - name: METRICS_ENDPOINTS_EXPOSE
+            value: "{{ .Values.metrics.endpoint.expose }}"
+          {{ - end }}
           envFrom:
           - configMapRef:
               name: {{ .Release.Name }}-node-db-config

--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -62,7 +62,7 @@ spec:
           - name: TB_SERVICE_ID
             value: "tb-node"
           - name: TB_SERVICE_TYPE
-            value: "{{ .Values.node.servicetype }}"
+            value: "{{ .Values.global.servicetype }}"
           - name: TB_QUEUE_TYPE
             value: "kafka"
           - name: ZOOKEEPER_ENABLED

--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -62,7 +62,7 @@ spec:
           - name: TB_SERVICE_ID
             value: "tb-node"
           - name: TB_SERVICE_TYPE
-            value: "monolith"
+            value: "{{ .Values.node.servicetype }}"
           - name: TB_QUEUE_TYPE
             value: "kafka"
           - name: ZOOKEEPER_ENABLED

--- a/helm/thingsboard/templates/node.yaml
+++ b/helm/thingsboard/templates/node.yaml
@@ -87,7 +87,7 @@ spec:
           - name: METRICS_ENABLED
             value: "{{ .Values.metrics.enabled }}"
           - name: METRICS_ENDPOINTS_EXPOSE
-            value: "{{ .Values.metrics.endpoint.expose }}"
+            value: "{{ .Values.metrics.endpoints.expose }}"
           {{ - end }}
           envFrom:
           - configMapRef:

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -76,7 +76,7 @@ node:
     port: 8080
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for ttemplates/node.yamlhe user. This also increases chances charts run on environments with little
+    # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
     # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
     # limits:

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -300,3 +300,10 @@ kafka:
   zookeeper:
     persistence:
       enabled: false
+
+#Enable metrics for prometheus, add environment variables to tb-node pod
+metrics:
+  enabled: false
+  # if metrics are enabled, need to set the endponts expose to prometheus
+  # endpoints:
+  #   expose: prometheus

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -22,7 +22,7 @@ global:
     pullPolicy: Always
   jsonLogs: false
   # set the TB_SERVICE_TYPE ENV to be monolith or tb-core or tb-rule-engine
-  servicetype: tb-core
+  servicetype: monolith
 
 nameOverride: ""
 fullnameOverride: ""

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -237,7 +237,7 @@ webui:
   podSecurityContext: {}
   securityContext: {}
   service:
-    type: ClusterIPtemplates/node.yaml
+    type: ClusterIP
     port: 8084
   resources: {}
   autoscaling:

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -21,6 +21,8 @@ global:
     pullSecrets: []
     pullPolicy: Always
   jsonLogs: false
+  # set the TB_SERVICE_TYPE ENV to be monolith or tb_core or tb_rule_engine
+  servicetype: tb_core
 
 nameOverride: ""
 fullnameOverride: ""
@@ -74,7 +76,7 @@ node:
     port: 8080
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
+    # choice for ttemplates/node.yamlhe user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
     # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
     # limits:
@@ -92,6 +94,7 @@ node:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  
 
 jsexecutor:
   # kind can be either Deployment or StatefulSet
@@ -234,7 +237,7 @@ webui:
   podSecurityContext: {}
   securityContext: {}
   service:
-    type: ClusterIP
+    type: ClusterIPtemplates/node.yaml
     port: 8084
   resources: {}
   autoscaling:

--- a/helm/thingsboard/values.yaml
+++ b/helm/thingsboard/values.yaml
@@ -21,8 +21,8 @@ global:
     pullSecrets: []
     pullPolicy: Always
   jsonLogs: false
-  # set the TB_SERVICE_TYPE ENV to be monolith or tb_core or tb_rule_engine
-  servicetype: tb_core
+  # set the TB_SERVICE_TYPE ENV to be monolith or tb-core or tb-rule-engine
+  servicetype: tb-core
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Extend helm chart node.yaml template to be able to set METRICS_ENABLED and METRICS_ENDPOINTS_EXPOSE variables to expose metrics to prometheus. Also adjust values.yaml to contain these values. 
Also extend helm chart to be able to set the servicetype variable, which can be not only monolith, but tb-core or tb-rule-engine as well.
