### PR TITLE
Logging for ELK stack. Keywords: Elasticsearch, Logstash, Kibana, Filebeat

### DIFF
--- a/logging/README.md
+++ b/logging/README.md
@@ -1,0 +1,29 @@
+### Logging on ELK stack (Elasticsearch, Logstash, Kibana)
+
+The agent that scrapes raw logs is a *filebeat* by Elastic. It runs on each node and set as a *daemonset*.
+
+All filebeat agents are generally watching and tailing log files and pack each log as message to logstash with some metadata.
+The most valuable function configured for ThingsBoard stack is a multiline template that recognizes multiline logs as a single message.
+As a result you will get a Java stacktrace or json payload as a single message on the Kibana UI!
+
+The *logstash* service are responsible for gathering logs from filebeats, *converting* logs from raw string to *structured columns* and sending to the ElasticSearch by https using *batching* and *compression*
+
+**Before you install** logging please fill the `logstash-secret.yml` with your endpoint, user and password to supply data
+Please avoid storing an unencrypted secrets in VCS (git) repo.
+
+Make sure you stick logstash to monitoring like nodegroup or some affinity rules added
+
+```bash
+cd logging
+./install-logging.sh
+```
+
+Note: ElasticSearch does not have a data retention policy enabled by default. It will consume data until run out of disk space. Kindly recommended to setup a data retention policy (log rotation)
+
+# Useful commands
+
+```bash
+kubectl get ds -A
+kubectl get pods -n logging
+kubectl logs -f --tail 99 logstash-0 -n logging
+```

--- a/logging/delete-logging.sh
+++ b/logging/delete-logging.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+kubectl delete -f filebeat-daemonset.yml
+kubectl delete -f filebeat-configmap.yml
+kubectl delete -f filebeat-authorization.yml
+
+kubectl delete -f logstash-service.yml
+kubectl delete -f logstash.yml
+kubectl delete -f logstash-configmap.yml
+kubectl delete -f logstash-secret.yml
+
+kubectl delete -f logging-namespace.yml

--- a/logging/filebeat-authorization.yml
+++ b/logging/filebeat-authorization.yml
@@ -1,0 +1,46 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: filebeat
+subjects:
+  - kind: ServiceAccount
+    name: filebeat
+    namespace: logging
+roleRef:
+  kind: ClusterRole
+  name: filebeat
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: filebeat
+  labels:
+    app: filebeat
+rules:
+  - apiGroups: [ "" ] # "" indicates the core API group
+    resources:
+      - namespaces
+      - pods
+      - nodes
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups: [ "apps" ]
+    resources:
+      - replicasets
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "batch" ]
+    resources:
+      - jobs
+    verbs: [ "get", "list", "watch" ]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: filebeat
+  labels:
+    app: filebeat
+  namespace: logging
+---

--- a/logging/filebeat-configmap.yml
+++ b/logging/filebeat-configmap.yml
@@ -1,0 +1,161 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: filebeat-config
+  namespace: logging
+  labels:
+    app: filebeat
+data:
+  filebeat.yml: |-
+    pipeline.ecs_compatibility: v1
+    filebeat.autodiscover:
+      providers:
+        - type: kubernetes
+          node: ${NODE_NAME}
+          hints.enabled: true
+          hints.default_config:
+            type: container
+            paths:
+              - /var/log/containers/*${data.kubernetes.container.id}.log
+    # Thingsboard Java logback
+    # 2023-08-29 19:02:13,959 [tb-core-integrations-consumer-50-thread-1] WARN  o.t.s.s.q.DefaultTbCoreConsumerService - Failed to process integration msg
+          templates:
+            - condition.contains.kubernetes.pod.name: "tb-core"
+              config:
+                - type: container
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+                  multiline:
+                    pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \['
+                    negate: true
+                    match: after
+            - condition.contains.kubernetes.pod.name: "tb-node"
+              config:
+                - type: container
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+                  multiline:
+                    pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \['
+                    negate: true
+                    match: after                
+            - condition.contains.kubernetes.pod.name: "tb-db-setup"
+              config:
+                - type: container
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+                  multiline:
+                    pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \['
+                    negate: true
+                    match: after          
+            - condition.contains.kubernetes.pod.name: "tb-rule"
+              config:
+                - type: container
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+                  multiline:
+                    pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \['
+                    negate: true
+                    match: after
+            - condition.contains.kubernetes.pod.name: "tb-ie"
+              config:
+                - type: container
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+                  multiline:
+                    pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \['
+                    negate: true
+                    match: after
+            - condition.contains.kubernetes.pod.name: "tb-vc"
+              config:
+                - type: container
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+                  multiline:
+                    pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \['
+                    negate: true
+                    match: after
+            - condition.contains.kubernetes.pod.name: "tb-edqs"
+              config:
+                - type: container
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+                  multiline:
+                    pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \['
+                    negate: true
+                    match: after
+            - condition.contains.kubernetes.pod.name: "-transport"
+              config:
+                - type: container
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+                  multiline:
+                    pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \['
+                    negate: true
+                    match: after
+            - condition.contains.kubernetes.pod.name: "tb-edge"
+              config:
+                - type: container
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+                  multiline:
+                    pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \['
+                    negate: true
+                    match: after
+            - condition.contains.kubernetes.pod.name: "tb-broker"
+              config:
+                - type: container
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+                  multiline:
+                    pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \['
+                    negate: true
+                    match: after
+    # Thingsboard JS logs
+    # 2023-08-29 14:32:06,499 [kafkajs] INFO: Starting: {"timestamp":"2023-08-29T14:32:06.499Z","logger":"kafkajs","groupId":"js-executor-group"}
+            - condition.contains.kubernetes.pod.name: "tb-js"
+              config:
+                - type: container
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+                  multiline:
+                    pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \['
+                    negate: true
+                    match: after
+            - condition.contains.kubernetes.pod.name: "tb-web"
+              config:
+                - type: container
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+                  multiline:
+                    pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \['
+                    negate: true
+                    match: after                
+    # Kafka
+    # [2023-08-29 20:47:02,878] INFO [LocalLog partition=tb_rule_engine.main.1-0, dir=/bitnami/kafka/data] Rolled new log segment at offset 233322445 in 1 ms. (kafka.log.LocalLog)
+    # [2023-08-29 20:47:02,883] INFO [ProducerStateManager partition=tb_rule_engine.main.1-0] Wrote producer snapshot at offset 233322445 with 0 producer ids in 5 ms. (kafka.log.ProducerStateManager)
+            - condition.contains.kubernetes.container.name: "kafka"
+              config:
+                - type: container
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+                  multiline:
+                    pattern: '^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\] '
+                    negate: true
+                    match: after
+    # Cassandra
+    # INFO  [ScheduledTasks:1] 2023-08-29 21:08:51,850 NoSpamLogger.java:91 - Some operations were slow, details available at debug level (debug.log)
+    # INFO  [ReadStage-8] 2023-08-29 20:59:15,539 NoSpamLogger.java:91 - Maximum memory usage reached (536870912), cannot allocate chunk of 1048576
+            - condition.contains.kubernetes.container.name: "cassandra"
+              config:
+                - type: container
+                  paths:
+                    - /var/log/containers/*${data.kubernetes.container.id}.log
+                  multiline:
+                    pattern: '^\S{4,5} ? \[.*\] \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} '
+                    negate: true
+                    match: after
+    processors:
+      - add_cloud_metadata:
+    #  - add_host_metadata:
+    output.logstash:
+      hosts: '${LOGSTASH_URL}'

--- a/logging/filebeat-daemonset.yml
+++ b/logging/filebeat-daemonset.yml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: filebeat
+  namespace: logging
+  labels:
+    app: filebeat
+spec:
+  selector:
+    matchLabels:
+      app: filebeat
+  template:
+    metadata:
+      labels:
+        app: filebeat
+    spec:
+      serviceAccountName: filebeat
+      terminationGracePeriodSeconds: 30
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: filebeat
+          image: elastic/filebeat:8.17.3
+          args: [
+            "-c", "/etc/filebeat.yml",
+            "-e",
+          ]
+          env:
+            - name: LOGSTASH_URL
+              value: "logstash:5044"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            runAsUser: 0
+            # If using Red Hat OpenShift uncomment this:
+            #privileged: true
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 25m
+              memory: 100Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/filebeat.yml
+              readOnly: true
+              subPath: filebeat.yml
+            - name: data
+              mountPath: /usr/share/filebeat/data
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            defaultMode: 0600
+            name: filebeat-config
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: varlog
+          hostPath:
+            path: /var/log
+        # data folder stores a registry of read status for all files, so we don't send everything again on a Filebeat pod restart
+        - name: data
+          hostPath:
+            path: /var/lib/filebeat-data
+            type: DirectoryOrCreate

--- a/logging/install-logging.sh
+++ b/logging/install-logging.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+kubectl apply -f logging-namespace.yml
+kubectl apply -f logstash-secret.yml
+kubectl apply -f logstash-configmap.yml
+kubectl apply -f logstash.yml
+kubectl apply -f logstash-service.yml
+
+kubectl apply -f filebeat-authorization.yml
+kubectl apply -f filebeat-configmap.yml
+kubectl apply -f filebeat-daemonset.yml

--- a/logging/logging-namespace.yml
+++ b/logging/logging-namespace.yml
@@ -1,0 +1,38 @@
+#
+# ThingsBoard, Inc. ("COMPANY") CONFIDENTIAL
+#
+# Copyright © 2016-2020 ThingsBoard, Inc. All Rights Reserved.
+#
+# NOTICE: All information contained herein is, and remains
+# the property of ThingsBoard, Inc. and its suppliers,
+# if any.  The intellectual and technical concepts contained
+# herein are proprietary to ThingsBoard, Inc.
+# and its suppliers and may be covered by U.S. and Foreign Patents,
+# patents in process, and are protected by trade secret or copyright law.
+#
+# Dissemination of this information or reproduction of this material is strictly forbidden
+# unless prior written permission is obtained from COMPANY.
+#
+# Access to the source code contained herein is hereby forbidden to anyone except current COMPANY employees,
+# managers or contractors who have executed Confidentiality and Non-disclosure agreements
+# explicitly covering such access.
+#
+# The copyright notice above does not evidence any actual or intended publication
+# or disclosure  of  this source code, which includes
+# information that is confidential and/or proprietary, and is a trade secret, of  COMPANY.
+# ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC  PERFORMANCE,
+# OR PUBLIC DISPLAY OF OR THROUGH USE  OF THIS  SOURCE CODE  WITHOUT
+# THE EXPRESS WRITTEN CONSENT OF COMPANY IS STRICTLY PROHIBITED,
+# AND IN VIOLATION OF APPLICABLE LAWS AND INTERNATIONAL TREATIES.
+# THE RECEIPT OR POSSESSION OF THIS SOURCE CODE AND/OR RELATED INFORMATION
+# DOES NOT CONVEY OR IMPLY ANY RIGHTS TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS,
+# OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
+#
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logging
+  labels:
+    name: logging
+

--- a/logging/logstash-configmap.yml
+++ b/logging/logstash-configmap.yml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logstash-configmap
+  namespace: logging
+data:
+  logstash.yml: |
+    http.host: "0.0.0.0"
+    path.config: /usr/share/logstash/pipeline
+    pipeline.ecs_compatibility: v1
+  logstash.conf: |
+    # all input will come from filebeat, no local logs
+    input {
+      beats {
+        port => 5044
+      }
+    }
+    filter {
+      if [kubernetes][pod][name] =~ "^tb-core|tb-db-setup|tb-rule|tb-ie|tb-vc|tb-edqs|-transport|tb-edge-\d|tb-broker-\d" {
+        grok {
+          match => { "message" => "(?m)%{TIMESTAMP_ISO8601:Date}%{SPACE}\[%{DATA:ThreadName}\]%{SPACE}%{LOGLEVEL:Level}%{SPACE}%{JAVACLASS:Class}%{SPACE}-%{SPACE}%{GREEDYDATA:message}" }
+          overwrite => [ "message" ]
+        }
+      } else if [kubernetes][pod][name] =~ "^tb-js|tb-web" {
+        grok {
+          match => { "message" => "(?m)%{TIMESTAMP_ISO8601:Date}%{SPACE}\[%{DATA:Class}\]%{SPACE}%{LOGLEVEL:Level}:%{SPACE}%{GREEDYDATA:message}" }
+          overwrite => [ "message" ]
+        }
+      } else if [kubernetes][container][name] =~ "^kafka" {
+        grok {
+          match => { "message" => "(?m)\[%{TIMESTAMP_ISO8601:Date}\]%{SPACE}%{LOGLEVEL:Level}%{SPACE}(\[%{DATA:ThreadName}\])?%{SPACE}%{GREEDYDATA:message} \(%{JAVACLASS:Class}\)" }
+          overwrite => [ "message" ]
+        }
+      } else if [kubernetes][container][name] =~ "^cassandra" {
+        grok {
+          match => { "message" => "(?m)%{LOGLEVEL:Level}%{SPACE}\[%{DATA:ThreadName}\]%{SPACE}%{TIMESTAMP_ISO8601:Date}%{SPACE}%{JAVACLASS:Class}\:%{INT:line} - %{GREEDYDATA:message}" }
+          overwrite => [ "message" ]
+        }
+      } else {
+      }
+      if [Date] {
+        date {
+          match => [ "Date", "ISO8601", "MMM dd yyyy HH:mm:ss" ]
+          remove_field => [ "Date" ]
+        }
+      }
+    }
+    output {
+      elasticsearch {
+        data_stream => "true"
+        data_stream_type => "logs"
+        data_stream_dataset => "thingsboard"
+        data_stream_namespace => "qa"
+        hosts => [ "${ES_HOSTS}" ]
+        user => "${ES_USER}"
+        password => "${ES_PASSWORD}"
+        http_compression => "true"
+      }
+    }

--- a/logging/logstash-secret.yml
+++ b/logging/logstash-secret.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: logstash
+  namespace: logging
+type: Opaque
+# WARN: DO NOT store unencrypted secret value in VCS (Git). Base64 is not an encryption. Take a look on SealedSecret or similar
+stringData:
+  ES_HOSTS: "https://elastic.your.domain:443"
+  ES_USER: "elastic_username"
+  ES_PASSWORD: "put__your__super__strong__password__here"

--- a/logging/logstash-service.yml
+++ b/logging/logstash-service.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: logstash
+  name: logstash
+  namespace: logging
+spec:
+  ports:
+    - name: "25826"
+      port: 25826
+      targetPort: 25826
+    - name: "5044"
+      port: 5044
+      targetPort: 5044
+  selector:
+    app: logstash

--- a/logging/logstash.yml
+++ b/logging/logstash.yml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: logstash
+  namespace: logging
+spec:
+  serviceName: logstash
+  replicas: 1
+  selector:
+    matchLabels:
+      app: logstash
+  template:
+    metadata:
+      labels:
+        app: logstash
+      name: logstash
+    spec:
+#      nodeSelector:
+#        role: monitoring
+      containers:
+        - image: elastic/logstash:8.17.3
+          name: logstash
+          ports:
+            - containerPort: 25826
+            - containerPort: 5044
+          envFrom:
+            - secretRef:
+                name: logstash
+          env:
+            - name: LS_JAVA_OPTS
+              value: "-Xms640m -Xmx640m -Xss256k -XX:+AlwaysPreTouch -Dio.netty.allocator.maxOrder=12"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 1500Mi
+            limits:
+              cpu: 2000m
+              memory: 1500Mi
+          volumeMounts:
+            - name: config-volume
+              mountPath: /usr/share/logstash/config
+            - name: logstash-pipeline-volume
+              mountPath: /usr/share/logstash/pipeline
+      restartPolicy: Always
+      volumes:
+        - name: config-volume
+          configMap:
+            name: logstash-configmap
+            items:
+              - key: logstash.yml
+                path: logstash.yml
+        - name: logstash-pipeline-volume
+          configMap:
+            name: logstash-configmap
+            items:
+              - key: logstash.conf
+                path: logstash.conf


### PR DESCRIPTION
## Logging on ELK stack (Elasticsearch, Logstash, Kibana)

The agent that scrapes raw logs is a *filebeat* by Elastic. It runs on each node and set as a *daemonset*.

All filebeat agents are generally watching and tailing log files and pack each log as message to logstash with some metadata.
The most valuable function configured for ThingsBoard stack is a multiline template that recognizes multiline logs as a single message.
As a result you will get a Java stacktrace or json payload as a single message on the Kibana UI!

The *logstash* service are responsible for gathering logs from filebeats, *converting* logs from raw string to *structured columns* and sending to the ElasticSearch by https using *batching* and *compression*

**Before you install** logging please fill the `logstash-secret.yml` with your endpoint, user and password to supply data
Please avoid storing an unencrypted secrets in VCS (git) repo.

Make sure you stick logstash to monitoring like nodegroup or some affinity rules added

```bash
cd logging
./install-logging.sh
```

Note: ElasticSearch does not have a data retention policy enabled by default. It will consume data until run out of disk space. Kindly recommended to setup a data retention policy (log rotation)

## Useful commands

```bash
kubectl get ds -A
kubectl get pods -n logging
kubectl logs -f --tail 99 logstash-0 -n logging
```


## Structured logs expected from the data stream provided

![image](https://github.com/user-attachments/assets/f8e1e477-1af0-4107-a2ab-5b6b5868cb4b)
