### PR TITLE
Upgrade Cassandra from version 4.0.1 to 5.0.4 in all Kubernetes deployment files

### DIFF
--- a/aws/microservices/receipts/cassandra.yml
+++ b/aws/microservices/receipts/cassandra.yml
@@ -83,7 +83,7 @@ spec:
       terminationGracePeriodSeconds: 1800
       containers:
         - name: cassandra
-          image: cassandra:4.0.1
+          image: cassandra:5.0.4
           imagePullPolicy: Always
           ports:
             - containerPort: 7000
@@ -135,7 +135,7 @@ spec:
                 - /bin/bash
                 - -c
                 - /probe/ready-probe.sh
-            initialDelaySeconds: 60
+            initialDelaySeconds: 90
             timeoutSeconds: 5
           volumeMounts:
             - name: cassandra-probe-config

--- a/aws/monolith/receipts/cassandra.yml
+++ b/aws/monolith/receipts/cassandra.yml
@@ -83,7 +83,7 @@ spec:
       terminationGracePeriodSeconds: 1800
       containers:
         - name: cassandra
-          image: cassandra:4.0.1
+          image: cassandra:5.0.4
           imagePullPolicy: Always
           ports:
             - containerPort: 7000
@@ -135,7 +135,7 @@ spec:
                 - /bin/bash
                 - -c
                 - /probe/ready-probe.sh
-            initialDelaySeconds: 60
+            initialDelaySeconds: 90
             timeoutSeconds: 5
           volumeMounts:
             - name: cassandra-probe-config

--- a/azure/microservices/receipts/cassandra.yml
+++ b/azure/microservices/receipts/cassandra.yml
@@ -83,7 +83,7 @@ spec:
       terminationGracePeriodSeconds: 1800
       containers:
       - name: cassandra
-        image: cassandra:4.0.1
+        image: cassandra:5.0.4
         imagePullPolicy: Always
         ports:
         - containerPort: 7000
@@ -133,7 +133,7 @@ spec:
             - /bin/bash
             - -c
             - /probe/ready-probe.sh
-          initialDelaySeconds: 60
+          initialDelaySeconds: 90
           timeoutSeconds: 5
         volumeMounts:
         - name: cassandra-probe-config

--- a/azure/monolith/receipts/cassandra.yml
+++ b/azure/monolith/receipts/cassandra.yml
@@ -83,7 +83,7 @@ spec:
       terminationGracePeriodSeconds: 1800
       containers:
       - name: cassandra
-        image: cassandra:4.0.1
+        image: cassandra:5.0.4
         imagePullPolicy: Always
         ports:
         - containerPort: 7000
@@ -133,7 +133,7 @@ spec:
             - /bin/bash
             - -c
             - /probe/ready-probe.sh
-          initialDelaySeconds: 60
+          initialDelaySeconds: 90
           timeoutSeconds: 5
         volumeMounts:
         - name: cassandra-probe-config

--- a/gcp/microservices/receipts/cassandra.yml
+++ b/gcp/microservices/receipts/cassandra.yml
@@ -83,7 +83,7 @@ spec:
       terminationGracePeriodSeconds: 1800
       containers:
       - name: cassandra
-        image: cassandra:4.0.1
+        image: cassandra:5.0.4
         imagePullPolicy: Always
         ports:
         - containerPort: 7000
@@ -133,7 +133,7 @@ spec:
             - /bin/bash
             - -c
             - /probe/ready-probe.sh
-          initialDelaySeconds: 60
+          initialDelaySeconds: 90
           timeoutSeconds: 5
         volumeMounts:
         - name: cassandra-probe-config

--- a/gcp/monolith/receipts/cassandra.yml
+++ b/gcp/monolith/receipts/cassandra.yml
@@ -83,7 +83,7 @@ spec:
       terminationGracePeriodSeconds: 1800
       containers:
       - name: cassandra
-        image: cassandra:4.0.1
+        image: cassandra:5.0.4
         imagePullPolicy: Always
         ports:
         - containerPort: 7000
@@ -133,7 +133,7 @@ spec:
             - /bin/bash
             - -c
             - /probe/ready-probe.sh
-          initialDelaySeconds: 60
+          initialDelaySeconds: 90
           timeoutSeconds: 5
         volumeMounts:
         - name: cassandra-probe-config

--- a/minikube/cassandra.yml
+++ b/minikube/cassandra.yml
@@ -64,7 +64,7 @@ spec:
       terminationGracePeriodSeconds: 1800
       containers:
       - name: cassandra
-        image: cassandra:4.0.1
+        image: cassandra:5.0.4
         imagePullPolicy: Always
         ports:
         - containerPort: 7000
@@ -118,7 +118,7 @@ spec:
             - /bin/bash
             - -c
             - /probe/ready-probe.sh
-          initialDelaySeconds: 60
+          initialDelaySeconds: 90
           timeoutSeconds: 5
         volumeMounts:
         - name: cassandra-probe-config

--- a/openshift/cassandra.yml
+++ b/openshift/cassandra.yml
@@ -64,7 +64,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: cassandra
-        image: cassandra:4.0.1
+        image: cassandra:5.0.4
         imagePullPolicy: Always
         ports:
         - containerPort: 7000
@@ -114,7 +114,7 @@ spec:
             - /bin/bash
             - -c
             - /probe/ready-probe.sh
-          initialDelaySeconds: 60
+          initialDelaySeconds: 90
           timeoutSeconds: 5
         volumeMounts:
         - name: cassandra-probe-config


### PR DESCRIPTION
**Changes**

- Cassandra image version from **4.0.1** to **5.0.4**
- Increase **initialDelaySeconds** from 60 to 90

**Testing**

- Deployed locally via minikube
- Verified successful ThingsBoard installation and pod startup
- Testing log files attached

[buffered-executor.log](https://github.com/user-attachments/files/20163700/buffered-executor.log)
[cassandra.log](https://github.com/user-attachments/files/20163702/cassandra.log)
[thingsboard-installation.log](https://github.com/user-attachments/files/20163704/thingsboard-installation.log)
