### PR TITLE
Update kafka to bitnami/kafka:4.0.0

### DIFF
--- a/aws/microservices/tb-kafka-configmap.yml
+++ b/aws/microservices/tb-kafka-configmap.yml
@@ -24,3 +24,20 @@ metadata:
 data:
   TB_QUEUE_TYPE: kafka
   TB_KAFKA_SERVERS: YOUR_MSK_BOOTSTRAP_SERVERS_PLAINTEXT
+  TB_QUEUE_KAFKA_REPLICATION_FACTOR: "3"
+  TB_KAFKA_ACKS: "1"
+
+  #Advanced section
+  TB_KAFKA_COMPRESSION_TYPE: gzip
+  TB_KAFKA_BATCH_SIZE: "65536"
+  TB_KAFKA_LINGER_MS: "5"
+  TB_QUEUE_KAFKA_MAX_POLL_RECORDS: "1024"
+  #retention 24 hours or 512 mb
+  TB_QUEUE_KAFKA_RE_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:1;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_CORE_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:1;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_TA_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_NOTIFICATIONS_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:1;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_JE_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_OTA_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_VC_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_INTEGRATION_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"

--- a/aws/microservices/tb-kafka.yml
+++ b/aws/microservices/tb-kafka.yml
@@ -91,35 +91,61 @@ spec:
           image: bitnami/kafka:4.0.0
           ports:
             - containerPort: 9092
-              name: kafka-int
-          readinessProbe:
-            periodSeconds: 20
+              name: client
+            - containerPort: 9093
+              name: controller
+          startupProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 15
+            successThreshold: 1
             tcpSocket:
-              port: 9092
+              port: "controller"
           livenessProbe:
-            initialDelaySeconds: 25
-            periodSeconds: 5
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            exec:
+              command:
+                - pgrep
+                - -f
+                - kafka
+          readinessProbe:
+            initialDelaySeconds: 15
+            failureThreshold: 10
+            timeoutSeconds: 5
+            periodSeconds: 15
+            successThreshold: 1
             tcpSocket:
-              port: 9092
+              port: "controller"
           env:
             - name: KAFKA_CLUSTER_ID
               value: "A0SZ6TGET1mhlQYl49uBSQ"
             - name: ALLOW_PLAINTEXT_LISTENER
               value: "yes"
             - name: KAFKA_CFG_LISTENERS
-              value: "INSIDE://:9092,CONTROLLER://:9093"
+              value: "PLAINTEXT://:9092,CONTROLLER://:9093"
             - name: KAFKA_CFG_ADVERTISED_LISTENERS
-              value: "INSIDE://:9092"
+              value: "PLAINTEXT://:9092"
             - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
-              value: "INSIDE:PLAINTEXT,CONTROLLER:PLAINTEXT"
+              value: "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"
             - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
-              value: "INSIDE"
+              value: "PLAINTEXT"
             - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
               value: "0@tb-kafka-0.tb-kafka.thingsboard.svc.cluster.local:9093,1@tb-kafka-1.tb-kafka.thingsboard.svc.cluster.local:9093,2@tb-kafka-2.tb-kafka.thingsboard.svc.cluster.local:9093"
             - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
               value: "CONTROLLER"
             - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
               value: "false"
+            - name: KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "3"
+            - name: KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "3"
+            - name: KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "2"
             - name: KAFKA_CFG_LOG_RETENTION_BYTES
               value: "1073741824"
             - name: KAFKA_CFG_SEGMENT_BYTES
@@ -196,4 +222,6 @@ spec:
     app: tb-kafka
   ports:
     - port: 9092
-      name: kafka-int
+      name: client
+    - port: 9093
+      name: controller

--- a/aws/microservices/tb-kafka.yml
+++ b/aws/microservices/tb-kafka.yml
@@ -142,10 +142,8 @@ spec:
               value: "/kafka-data/logs"
             - name: KAFKA_CFG_PROCESS_ROLES
               value: "controller,broker"
-            - name: KAFKA_CFG_NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+            - name: KAFKA_NODE_ID_COMMAND
+              value: "hostname | cut -d'-' -f3"
           resources:
             requests:
               cpu: "300m"

--- a/aws/microservices/tb-kafka.yml
+++ b/aws/microservices/tb-kafka.yml
@@ -79,7 +79,7 @@ spec:
                   - key: "app"
                     operator: In
                     values:
-                      - kafka
+                      - tb-kafka
               topologyKey: "kubernetes.io/hostname"
       securityContext:
         runAsUser: 799
@@ -88,17 +88,10 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: bitnami/kafka:3.8.1
+          image: bitnami/kafka:4.0.0
           ports:
             - containerPort: 9092
               name: kafka-int
-          resources:
-            limits:
-              cpu: "1000m"
-              memory: 2500Mi
-            requests:
-              cpu: "1000m"
-              memory: 2500Mi
           readinessProbe:
             periodSeconds: 20
             tcpSocket:
@@ -109,20 +102,22 @@ spec:
             tcpSocket:
               port: 9092
           env:
-            - name: BROKER_ID_COMMAND
-              value: "hostname | cut -d'-' -f3"
+            - name: KAFKA_CLUSTER_ID
+              value: "A0SZ6TGET1mhlQYl49uBSQ"
             - name: ALLOW_PLAINTEXT_LISTENER
               value: "yes"
-            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
-              value: "zookeeper:2181"
             - name: KAFKA_CFG_LISTENERS
-              value: "INSIDE://:9092"
+              value: "INSIDE://:9092,CONTROLLER://:9093"
             - name: KAFKA_CFG_ADVERTISED_LISTENERS
               value: "INSIDE://:9092"
             - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
-              value: "INSIDE:PLAINTEXT"
+              value: "INSIDE:PLAINTEXT,CONTROLLER:PLAINTEXT"
             - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
               value: "INSIDE"
+            - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
+              value: "0@tb-kafka-0.tb-kafka.thingsboard.svc.cluster.local:9093,1@tb-kafka-1.tb-kafka.thingsboard.svc.cluster.local:9093,2@tb-kafka-2.tb-kafka.thingsboard.svc.cluster.local:9093"
+            - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
             - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
               value: "false"
             - name: KAFKA_CFG_LOG_RETENTION_BYTES
@@ -139,14 +134,25 @@ spec:
               value: "1"
             - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
               value: "1"
-            - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
-              value: "30000"
             - name: KAFKA_PORT
               value: "9092"
             - name: KAFKA_OPTS
               value: "-Xms1G -Xmx1G -XX:+AlwaysPreTouch"
             - name: KAFKA_LOG_DIRS
               value: "/kafka-data/logs"
+            - name: KAFKA_CFG_PROCESS_ROLES
+              value: "controller,broker"
+            - name: KAFKA_CFG_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+          resources:
+            requests:
+              cpu: "300m"
+              memory: 1500Mi
+            limits:
+              cpu: "2000m"
+              memory: 1500Mi
           volumeMounts:
             - name: data-logs
               mountPath: /kafka-data

--- a/aws/microservices/tb-kafka.yml
+++ b/aws/microservices/tb-kafka.yml
@@ -14,161 +14,8 @@
 # limitations under the License.
 #
 
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: tb-zookeeper
-  namespace: thingsboard
-data:
-  start-node.sh: |
-    #!/bin/sh
-    set -ex;
-    mkdir -p "$ZOO_DATA_LOG_DIR" "$ZOO_DATA_DIR" "$ZOO_CONF_DIR";
-    echo $HOSTNAME| rev | cut -d "-" -f1 | rev > "$ZOO_DATA_DIR/myid"
-    zkServer.sh start-foreground /conf/zoo.cfg
-  zoo.cfg: |+
-    dataDir=/data
-    dataLogDir=/datalog
-    tickTime=2000
-    initLimit=5
-    syncLimit=2
-    maxClientCnxns=200
-    standaloneEnabled=true
-    server.0=zookeeper-0.zookeeper-headless.thingsboard.svc.cluster.local:2888:3888;2181
-    server.1=zookeeper-1.zookeeper-headless.thingsboard.svc.cluster.local:2888:3888;2181
-    server.2=zookeeper-2.zookeeper-headless.thingsboard.svc.cluster.local:2888:3888;2181
-  log4j.properties: |+
-    zookeeper.root.logger=INFO, CONSOLE
-    zookeeper.console.threshold=INFO
-    log4j.rootLogger=${zookeeper.root.logger}
-    log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-    log4j.appender.CONSOLE.Threshold=${zookeeper.console.threshold}
-    log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-    log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: zookeeper
-  namespace: thingsboard
-spec:
-  serviceName: "zookeeper-headless"
-  replicas: 3
-  podManagementPolicy: Parallel
-  selector:
-    matchLabels:
-      app: zookeeper
-  template:
-    metadata:
-      labels:
-        app: zookeeper
-    spec:
-      containers:
-        - name: zookeeper
-          imagePullPolicy: Always
-          image: zookeeper:3.5.7
-          ports:
-            - containerPort: 2181
-              name: client
-            - containerPort: 2888
-              name: server
-            - containerPort: 3888
-              name: election
-          resources:
-            limits:
-              cpu: "200m"
-              memory: 800Mi
-            requests:
-              cpu: "200m"
-              memory: 800Mi
-          command: ["/conf/start-node.sh"]
-          readinessProbe:
-            periodSeconds: 60
-            tcpSocket:
-              port: 2181
-          livenessProbe:
-            periodSeconds: 60
-            tcpSocket:
-              port: 2181
-          env:
-            - name: JVMFLAGS
-              value: "-Dzookeeper.electionPortBindRetry=0"
-            - name: HOSTNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-          volumeMounts:
-            - name: conf
-              mountPath: /conf
-              readOnly: false
-            - name: data
-              mountPath: /data
-              readOnly: false
-            - name: datalog
-              mountPath: /datalog
-              readOnly: false
-      volumes:
-        - name: conf
-          configMap:
-            name: tb-zookeeper
-            defaultMode: 0755
-  volumeClaimTemplates:
-    - metadata:
-        name: data
-      spec:
-        accessModes: [ "ReadWriteOnce" ]
-        resources:
-          requests:
-            storage: 100Mi
-    - metadata:
-        name: datalog
-      spec:
-        accessModes: [ "ReadWriteOnce" ]
-        resources:
-          requests:
-            storage: 100Mi
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: zookeeper
-  namespace: thingsboard
-spec:
-  type: ClusterIP
-  ports:
-    - port: 2181
-      targetPort: 2181
-      name: client
-    - port: 2888
-      targetPort: 2888
-      name: server
-    - port: 3888
-      targetPort: 3888
-      name: election
-  selector:
-    app: zookeeper
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: zookeeper-headless
-  namespace: thingsboard
-  labels:
-    app: zookeeper
-spec:
-  ports:
-    - port: 2181
-      targetPort: 2181
-      name: client
-    - port: 2888
-      targetPort: 2888
-      name: server
-    - port: 3888
-      targetPort: 3888
-      name: election
-  clusterIP: None
-  selector:
-    app: zookeeper
+#This is an optional deployment file. You can deploy Kafka inside EKS instead of AWS MSK
+#To use internal kafka deploy this file and set the TB_KAFKA_SERVERS: "tb-kafka:9092" in the tb-kafka-configmap.yml file
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -222,6 +69,8 @@ spec:
       labels:
         app: tb-kafka
     spec:
+      nodeSelector:
+        role: tb-node
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -316,12 +165,13 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data-logs
+        namespace: thingsboard
       spec:
         accessModes:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 25Gi
+            storage: 25000Mi
     - metadata:
         name: app-logs
       spec:
@@ -343,6 +193,3 @@ spec:
   ports:
     - port: 9092
       name: kafka-int
-  clusterIP: None
----
-

--- a/aws/microservices/zookeeper.yml
+++ b/aws/microservices/zookeeper.yml
@@ -76,7 +76,7 @@ spec:
       containers:
         - name: zookeeper
           imagePullPolicy: Always
-          image: zookeeper:3.5.7
+          image: zookeeper:3.8.1
           ports:
             - containerPort: 2181
               name: client

--- a/azure/microservices/tb-kafka-configmap.yml
+++ b/azure/microservices/tb-kafka-configmap.yml
@@ -24,3 +24,20 @@ metadata:
 data:
   TB_QUEUE_TYPE: kafka
   TB_KAFKA_SERVERS: tb-kafka:9092
+  TB_QUEUE_KAFKA_REPLICATION_FACTOR: "3"
+  TB_KAFKA_ACKS: "1"
+
+  #Advanced section
+  TB_KAFKA_COMPRESSION_TYPE: gzip
+  TB_KAFKA_BATCH_SIZE: "65536"
+  TB_KAFKA_LINGER_MS: "5"
+  TB_QUEUE_KAFKA_MAX_POLL_RECORDS: "1024"
+  #retention 24 hours or 512 mb
+  TB_QUEUE_KAFKA_RE_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:1;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_CORE_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:1;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_TA_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_NOTIFICATIONS_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:1;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_JE_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_OTA_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_VC_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_INTEGRATION_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"

--- a/azure/microservices/thirdparty.yml
+++ b/azure/microservices/thirdparty.yml
@@ -230,7 +230,7 @@ spec:
                   - key: "app"
                     operator: In
                     values:
-                      - kafka
+                      - tb-kafka
               topologyKey: "kubernetes.io/hostname"
       securityContext:
         runAsUser: 799
@@ -239,41 +239,36 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: bitnami/kafka:3.8.1
+          image: bitnami/kafka:4.0.0
           ports:
             - containerPort: 9092
               name: kafka-int
-          resources:
-            limits:
-              cpu: "1000m"
-              memory: 2500Mi
-            requests:
-              cpu: "1000m"
-              memory: 2500Mi
           readinessProbe:
             periodSeconds: 20
             tcpSocket:
               port: 9092
           livenessProbe:
-            initialDelaySeconds: 25
+            initialDelaySeconds: 65
             periodSeconds: 5
             tcpSocket:
               port: 9092
           env:
-            - name: BROKER_ID_COMMAND
-              value: "hostname | cut -d'-' -f3"
+            - name: KAFKA_CLUSTER_ID
+              value: "A0SZ6TGET1mhlQYl49uBSQ"
             - name: ALLOW_PLAINTEXT_LISTENER
               value: "yes"
-            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
-              value: "zookeeper:2181"
             - name: KAFKA_CFG_LISTENERS
-              value: "INSIDE://:9092"
+              value: "INSIDE://:9092,CONTROLLER://:9093"
             - name: KAFKA_CFG_ADVERTISED_LISTENERS
               value: "INSIDE://:9092"
             - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
-              value: "INSIDE:PLAINTEXT"
+              value: "INSIDE:PLAINTEXT,CONTROLLER:PLAINTEXT"
             - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
               value: "INSIDE"
+            - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
+              value: "0@tb-kafka-0.tb-kafka.thingsboard.svc.cluster.local:9093,1@tb-kafka-1.tb-kafka.thingsboard.svc.cluster.local:9093,2@tb-kafka-2.tb-kafka.thingsboard.svc.cluster.local:9093"
+            - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
             - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
               value: "false"
             - name: KAFKA_CFG_LOG_RETENTION_BYTES
@@ -290,14 +285,25 @@ spec:
               value: "1"
             - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
               value: "1"
-            - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
-              value: "30000"
             - name: KAFKA_PORT
               value: "9092"
             - name: KAFKA_OPTS
               value: "-Xms1G -Xmx1G -XX:+AlwaysPreTouch"
             - name: KAFKA_LOG_DIRS
               value: "/kafka-data/logs"
+            - name: KAFKA_CFG_PROCESS_ROLES
+              value: "controller,broker"
+            - name: KAFKA_CFG_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+          resources:
+            requests:
+              cpu: "300m"
+              memory: 1500Mi
+            limits:
+              cpu: "2000m"
+              memory: 1500Mi
           volumeMounts:
             - name: data-logs
               mountPath: /kafka-data

--- a/azure/microservices/thirdparty.yml
+++ b/azure/microservices/thirdparty.yml
@@ -293,10 +293,8 @@ spec:
               value: "/kafka-data/logs"
             - name: KAFKA_CFG_PROCESS_ROLES
               value: "controller,broker"
-            - name: KAFKA_CFG_NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+            - name: KAFKA_NODE_ID_COMMAND
+              value: "hostname | cut -d'-' -f3"
           resources:
             requests:
               cpu: "300m"

--- a/azure/microservices/thirdparty.yml
+++ b/azure/microservices/thirdparty.yml
@@ -242,35 +242,61 @@ spec:
           image: bitnami/kafka:4.0.0
           ports:
             - containerPort: 9092
-              name: kafka-int
-          readinessProbe:
-            periodSeconds: 20
+              name: client
+            - containerPort: 9093
+              name: controller
+          startupProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 15
+            successThreshold: 1
             tcpSocket:
-              port: 9092
+              port: "controller"
           livenessProbe:
-            initialDelaySeconds: 65
-            periodSeconds: 5
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            exec:
+              command:
+                - pgrep
+                - -f
+                - kafka
+          readinessProbe:
+            initialDelaySeconds: 15
+            failureThreshold: 10
+            timeoutSeconds: 5
+            periodSeconds: 15
+            successThreshold: 1
             tcpSocket:
-              port: 9092
+              port: "controller"
           env:
             - name: KAFKA_CLUSTER_ID
               value: "A0SZ6TGET1mhlQYl49uBSQ"
             - name: ALLOW_PLAINTEXT_LISTENER
               value: "yes"
             - name: KAFKA_CFG_LISTENERS
-              value: "INSIDE://:9092,CONTROLLER://:9093"
+              value: "PLAINTEXT://:9092,CONTROLLER://:9093"
             - name: KAFKA_CFG_ADVERTISED_LISTENERS
-              value: "INSIDE://:9092"
+              value: "PLAINTEXT://:9092"
             - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
-              value: "INSIDE:PLAINTEXT,CONTROLLER:PLAINTEXT"
+              value: "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"
             - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
-              value: "INSIDE"
+              value: "PLAINTEXT"
             - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
               value: "0@tb-kafka-0.tb-kafka.thingsboard.svc.cluster.local:9093,1@tb-kafka-1.tb-kafka.thingsboard.svc.cluster.local:9093,2@tb-kafka-2.tb-kafka.thingsboard.svc.cluster.local:9093"
             - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
               value: "CONTROLLER"
             - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
               value: "false"
+            - name: KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "3"
+            - name: KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "3"
+            - name: KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "2"
             - name: KAFKA_CFG_LOG_RETENTION_BYTES
               value: "1073741824"
             - name: KAFKA_CFG_SEGMENT_BYTES
@@ -346,7 +372,9 @@ spec:
     app: tb-kafka
   ports:
     - port: 9092
-      name: kafka-int
+      name: client
+    - port: 9093
+      name: controller
   clusterIP: None
 ---
 

--- a/azure/microservices/thirdparty.yml
+++ b/azure/microservices/thirdparty.yml
@@ -66,7 +66,7 @@ spec:
       containers:
         - name: zookeeper
           imagePullPolicy: Always
-          image: zookeeper:3.5.7
+          image: zookeeper:3.8.1
           ports:
             - containerPort: 2181
               name: client

--- a/gcp/microservices/tb-kafka-configmap.yml
+++ b/gcp/microservices/tb-kafka-configmap.yml
@@ -24,3 +24,20 @@ metadata:
 data:
   TB_QUEUE_TYPE: kafka
   TB_KAFKA_SERVERS: tb-kafka:9092
+  TB_QUEUE_KAFKA_REPLICATION_FACTOR: "3"
+  TB_KAFKA_ACKS: "1"
+
+  #Advanced section
+  TB_KAFKA_COMPRESSION_TYPE: gzip
+  TB_KAFKA_BATCH_SIZE: "65536"
+  TB_KAFKA_LINGER_MS: "5"
+  TB_QUEUE_KAFKA_MAX_POLL_RECORDS: "1024"
+  #retention 24 hours or 512 mb
+  TB_QUEUE_KAFKA_RE_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:1;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_CORE_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:1;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_TA_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_NOTIFICATIONS_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:1;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_JE_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_OTA_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_VC_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_INTEGRATION_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"

--- a/gcp/microservices/thirdparty.yml
+++ b/gcp/microservices/thirdparty.yml
@@ -178,22 +178,23 @@ metadata:
   name: tb-kafka
   namespace: thingsboard
 data:
-  start-node.sh: |
-    #!/bin/sh
-    cp /tmp/tools-log4j.properties /opt/kafka/config/tools-log4j.properties
-    cp /tmp/log4j.properties /opt/kafka/config/log4j.properties
-    /usr/bin/start-kafka.sh
   tools-log4j.properties: |+
     log4j.rootLogger=WARN, stdout
     log4j.appender.stdout=org.apache.log4j.ConsoleAppender
     log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
     log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
   log4j.properties: |+
-    log4j.rootLogger=INFO, stdout
+    log4j.rootLogger=INFO, stdout, kafkaAppender
 
     log4j.appender.stdout=org.apache.log4j.ConsoleAppender
     log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
     log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+    log4j.appender.kafkaAppender=org.apache.log4j.DailyRollingFileAppender
+    log4j.appender.kafkaAppender.DatePattern='.'yyyy-MM-dd-HH
+    log4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log
+    log4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout
+    log4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
     # Change the line below to adjust ZK client logging
     log4j.logger.org.apache.zookeeper=INFO
@@ -213,6 +214,7 @@ metadata:
   namespace: thingsboard
 spec:
   serviceName: "tb-kafka"
+  replicas: 3
   podManagementPolicy: Parallel
   selector:
     matchLabels:
@@ -224,21 +226,34 @@ spec:
     spec:
       nodeSelector:
         role: main
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                      - kafka
+              topologyKey: "kubernetes.io/hostname"
+      securityContext:
+        runAsUser: 799
+        runAsNonRoot: true
+        fsGroup: 799
       containers:
         - name: server
           imagePullPolicy: Always
-          image: wurstmeister/kafka:2.12-2.2.1
+          image: bitnami/kafka:3.8.1
           ports:
             - containerPort: 9092
               name: kafka-int
           resources:
             limits:
               cpu: "1000m"
-              memory: 4000Mi
+              memory: 2500Mi
             requests:
               cpu: "1000m"
-              memory: 4000Mi
-          command: ["/tmp/start-node.sh"]
+              memory: 2500Mi
           readinessProbe:
             periodSeconds: 20
             tcpSocket:
@@ -251,27 +266,27 @@ spec:
           env:
             - name: BROKER_ID_COMMAND
               value: "hostname | cut -d'-' -f3"
-            - name: KAFKA_ZOOKEEPER_CONNECT
+            - name: ALLOW_PLAINTEXT_LISTENER
+              value: "yes"
+            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
               value: "zookeeper:2181"
-            - name: KAFKA_LISTENERS
+            - name: KAFKA_CFG_LISTENERS
               value: "INSIDE://:9092"
-            - name: KAFKA_ADVERTISED_LISTENERS
+            - name: KAFKA_CFG_ADVERTISED_LISTENERS
               value: "INSIDE://:9092"
-            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+            - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
               value: "INSIDE:PLAINTEXT"
-            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+            - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
               value: "INSIDE"
-            - name: KAFKA_CREATE_TOPICS
-              value: "js_eval.requests:100:1:delete --config=retention.ms=60000 --config=segment.bytes=26214400 --config=retention.bytes=104857600,tb_transport.api.requests:30:1:delete --config=retention.ms=60000 --config=segment.bytes=26214400 --config=retention.bytes=104857600,tb_rule_engine:30:1:delete --config=retention.ms=60000 --config=segment.bytes=26214400 --config=retention.bytes=104857600"
-            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+            - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
               value: "false"
-            - name: KAFKA_LOG_RETENTION_BYTES
+            - name: KAFKA_CFG_LOG_RETENTION_BYTES
               value: "1073741824"
-            - name: KAFKA_LOG_SEGMENT_BYTES
+            - name: KAFKA_CFG_SEGMENT_BYTES
               value: "268435456"
-            - name: KAFKA_LOG_RETENTION_MS
+            - name: KAFKA_CFG_LOG_RETENTION_MS
               value: "300000"
-            - name: KAFKA_LOG_CLEANUP_POLICY
+            - name: KAFKA_CFG_LOG_CLEANUP_POLICY
               value: "delete"
             - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
               value: "1"
@@ -280,38 +295,37 @@ spec:
             - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
               value: "1"
             - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
-              value: "3000"
+              value: "30000"
             - name: KAFKA_PORT
               value: "9092"
+            - name: KAFKA_OPTS
+              value: "-Xms1G -Xmx1G -XX:+AlwaysPreTouch"
             - name: KAFKA_LOG_DIRS
-              value: "/kafka-logs/kafka"
+              value: "/kafka-data/logs"
           volumeMounts:
-            - name: logs
-              mountPath: /kafka-logs
-              readOnly: false
-            - name: start
-              mountPath: /tmp
+            - name: data-logs
+              mountPath: /kafka-data
               readOnly: false
             - name: app-logs
-              mountPath: /opt/kafka/logs
+              mountPath: /opt/bitnami/kafka/logs
               readOnly: false
-            - name: config
-              mountPath: /opt/kafka/config
+            - name: kafka-custom-config
+              mountPath: /bitnami/kafka/config
               readOnly: false
       volumes:
-        - name: start
+        - name: kafka-custom-config
           configMap:
             name: tb-kafka
             defaultMode: 0755
   volumeClaimTemplates:
     - metadata:
-        name: logs
+        name: data-logs
       spec:
         accessModes:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 10Gi
+            storage: 25Gi
     - metadata:
         name: app-logs
       spec:
@@ -319,15 +333,7 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 200Mi
-    - metadata:
-        name: config
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 50Mi
+            storage: 1000Mi
 ---
 apiVersion: v1
 kind: Service

--- a/gcp/microservices/thirdparty.yml
+++ b/gcp/microservices/thirdparty.yml
@@ -246,35 +246,61 @@ spec:
           image: bitnami/kafka:4.0.0
           ports:
             - containerPort: 9092
-              name: kafka-int
-          readinessProbe:
-            periodSeconds: 20
+              name: client
+            - containerPort: 9093
+              name: controller
+          startupProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 15
+            successThreshold: 1
             tcpSocket:
-              port: 9092
+              port: "controller"
           livenessProbe:
-            initialDelaySeconds: 65
-            periodSeconds: 5
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            exec:
+              command:
+                - pgrep
+                - -f
+                - kafka
+          readinessProbe:
+            initialDelaySeconds: 15
+            failureThreshold: 10
+            timeoutSeconds: 5
+            periodSeconds: 15
+            successThreshold: 1
             tcpSocket:
-              port: 9092
+              port: "controller"
           env:
             - name: KAFKA_CLUSTER_ID
               value: "A0SZ6TGET1mhlQYl49uBSQ"
             - name: ALLOW_PLAINTEXT_LISTENER
               value: "yes"
             - name: KAFKA_CFG_LISTENERS
-              value: "INSIDE://:9092,CONTROLLER://:9093"
+              value: "PLAINTEXT://:9092,CONTROLLER://:9093"
             - name: KAFKA_CFG_ADVERTISED_LISTENERS
-              value: "INSIDE://:9092"
+              value: "PLAINTEXT://:9092"
             - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
-              value: "INSIDE:PLAINTEXT,CONTROLLER:PLAINTEXT"
+              value: "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"
             - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
-              value: "INSIDE"
+              value: "PLAINTEXT"
             - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
               value: "0@tb-kafka-0.tb-kafka.thingsboard.svc.cluster.local:9093,1@tb-kafka-1.tb-kafka.thingsboard.svc.cluster.local:9093,2@tb-kafka-2.tb-kafka.thingsboard.svc.cluster.local:9093"
             - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
               value: "CONTROLLER"
             - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
               value: "false"
+            - name: KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "3"
+            - name: KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "3"
+            - name: KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "2"
             - name: KAFKA_CFG_LOG_RETENTION_BYTES
               value: "1073741824"
             - name: KAFKA_CFG_SEGMENT_BYTES
@@ -350,7 +376,9 @@ spec:
     app: tb-kafka
   ports:
     - port: 9092
-      name: kafka-int
+      name: client
+    - port: 9093
+      name: controller
   clusterIP: None
 ---
 apiVersion: apps/v1

--- a/gcp/microservices/thirdparty.yml
+++ b/gcp/microservices/thirdparty.yml
@@ -234,7 +234,7 @@ spec:
                   - key: "app"
                     operator: In
                     values:
-                      - kafka
+                      - tb-kafka
               topologyKey: "kubernetes.io/hostname"
       securityContext:
         runAsUser: 799
@@ -243,41 +243,36 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: bitnami/kafka:3.8.1
+          image: bitnami/kafka:4.0.0
           ports:
             - containerPort: 9092
               name: kafka-int
-          resources:
-            limits:
-              cpu: "1000m"
-              memory: 2500Mi
-            requests:
-              cpu: "1000m"
-              memory: 2500Mi
           readinessProbe:
             periodSeconds: 20
             tcpSocket:
               port: 9092
           livenessProbe:
-            initialDelaySeconds: 25
+            initialDelaySeconds: 65
             periodSeconds: 5
             tcpSocket:
               port: 9092
           env:
-            - name: BROKER_ID_COMMAND
-              value: "hostname | cut -d'-' -f3"
+            - name: KAFKA_CLUSTER_ID
+              value: "A0SZ6TGET1mhlQYl49uBSQ"
             - name: ALLOW_PLAINTEXT_LISTENER
               value: "yes"
-            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
-              value: "zookeeper:2181"
             - name: KAFKA_CFG_LISTENERS
-              value: "INSIDE://:9092"
+              value: "INSIDE://:9092,CONTROLLER://:9093"
             - name: KAFKA_CFG_ADVERTISED_LISTENERS
               value: "INSIDE://:9092"
             - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
-              value: "INSIDE:PLAINTEXT"
+              value: "INSIDE:PLAINTEXT,CONTROLLER:PLAINTEXT"
             - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
               value: "INSIDE"
+            - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
+              value: "0@tb-kafka-0.tb-kafka.thingsboard.svc.cluster.local:9093,1@tb-kafka-1.tb-kafka.thingsboard.svc.cluster.local:9093,2@tb-kafka-2.tb-kafka.thingsboard.svc.cluster.local:9093"
+            - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
             - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
               value: "false"
             - name: KAFKA_CFG_LOG_RETENTION_BYTES
@@ -294,14 +289,25 @@ spec:
               value: "1"
             - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
               value: "1"
-            - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
-              value: "30000"
             - name: KAFKA_PORT
               value: "9092"
             - name: KAFKA_OPTS
               value: "-Xms1G -Xmx1G -XX:+AlwaysPreTouch"
             - name: KAFKA_LOG_DIRS
               value: "/kafka-data/logs"
+            - name: KAFKA_CFG_PROCESS_ROLES
+              value: "controller,broker"
+            - name: KAFKA_CFG_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+          resources:
+            requests:
+              cpu: "300m"
+              memory: 1500Mi
+            limits:
+              cpu: "2000m"
+              memory: 1500Mi
           volumeMounts:
             - name: data-logs
               mountPath: /kafka-data

--- a/gcp/microservices/thirdparty.yml
+++ b/gcp/microservices/thirdparty.yml
@@ -297,10 +297,8 @@ spec:
               value: "/kafka-data/logs"
             - name: KAFKA_CFG_PROCESS_ROLES
               value: "controller,broker"
-            - name: KAFKA_CFG_NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+            - name: KAFKA_NODE_ID_COMMAND
+              value: "hostname | cut -d'-' -f3"
           resources:
             requests:
               cpu: "300m"

--- a/gcp/microservices/thirdparty.yml
+++ b/gcp/microservices/thirdparty.yml
@@ -68,7 +68,7 @@ spec:
       containers:
         - name: zookeeper
           imagePullPolicy: Always
-          image: zookeeper:3.5.7
+          image: zookeeper:3.8.1
           ports:
             - containerPort: 2181
               name: client

--- a/minikube/tb-kafka-configmap.yml
+++ b/minikube/tb-kafka-configmap.yml
@@ -24,3 +24,20 @@ metadata:
 data:
   TB_QUEUE_TYPE: kafka
   TB_KAFKA_SERVERS: tb-kafka:9092
+  TB_QUEUE_KAFKA_REPLICATION_FACTOR: "1"
+  TB_KAFKA_ACKS: "1"
+
+  #Advanced section
+  TB_KAFKA_COMPRESSION_TYPE: gzip
+  TB_KAFKA_BATCH_SIZE: "65536"
+  TB_KAFKA_LINGER_MS: "5"
+  TB_QUEUE_KAFKA_MAX_POLL_RECORDS: "1024"
+  #retention 24 hours or 512 mb
+  TB_QUEUE_KAFKA_RE_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:1;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_CORE_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:1;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_TA_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_NOTIFICATIONS_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:1;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_JE_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_OTA_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_VC_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_INTEGRATION_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"

--- a/minikube/thirdparty.yml
+++ b/minikube/thirdparty.yml
@@ -235,29 +235,49 @@ spec:
           image: bitnami/kafka:4.0.0
           ports:
             - containerPort: 9092
-              name: kafka-int
-          readinessProbe:
-            periodSeconds: 20
+              name: client
+            - containerPort: 9093
+              name: controller
+          startupProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 15
+            successThreshold: 1
             tcpSocket:
-              port: 9092
+              port: "controller"
           livenessProbe:
-            initialDelaySeconds: 65
-            periodSeconds: 5
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            exec:
+              command:
+                - pgrep
+                - -f
+                - kafka
+          readinessProbe:
+            initialDelaySeconds: 15
+            failureThreshold: 10
+            timeoutSeconds: 5
+            periodSeconds: 15
+            successThreshold: 1
             tcpSocket:
-              port: 9092
+              port: "controller"
           env:
             - name: KAFKA_CLUSTER_ID
               value: "A0SZ6TGET1mhlQYl49uBSQ"
             - name: ALLOW_PLAINTEXT_LISTENER
               value: "yes"
             - name: KAFKA_CFG_LISTENERS
-              value: "INSIDE://:9092,CONTROLLER://:9093"
+              value: "PLAINTEXT://:9092,CONTROLLER://:9093"
             - name: KAFKA_CFG_ADVERTISED_LISTENERS
-              value: "INSIDE://:9092"
+              value: "PLAINTEXT://:9092"
             - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
-              value: "INSIDE:PLAINTEXT,CONTROLLER:PLAINTEXT"
+              value: "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"
             - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
-              value: "INSIDE"
+              value: "PLAINTEXT"
             - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
               value: "0@tb-kafka-0.tb-kafka.thingsboard.svc.cluster.local:9093"
             - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
@@ -332,7 +352,9 @@ spec:
     app: tb-kafka
   ports:
     - port: 9092
-      name: kafka-int
+      name: client
+    - port: 9093
+      name: controller
   clusterIP: None
 ---
 apiVersion: apps/v1

--- a/minikube/thirdparty.yml
+++ b/minikube/thirdparty.yml
@@ -169,22 +169,23 @@ metadata:
   name: tb-kafka
   namespace: thingsboard
 data:
-  start-node.sh: |
-    #!/bin/sh
-    cp /tmp/tools-log4j.properties /opt/kafka/config/tools-log4j.properties
-    cp /tmp/log4j.properties /opt/kafka/config/log4j.properties
-    /usr/bin/start-kafka.sh
   tools-log4j.properties: |+
     log4j.rootLogger=WARN, stdout
     log4j.appender.stdout=org.apache.log4j.ConsoleAppender
     log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
     log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
   log4j.properties: |+
-    log4j.rootLogger=INFO, stdout
+    log4j.rootLogger=INFO, stdout, kafkaAppender
 
     log4j.appender.stdout=org.apache.log4j.ConsoleAppender
     log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
     log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+    log4j.appender.kafkaAppender=org.apache.log4j.DailyRollingFileAppender
+    log4j.appender.kafkaAppender.DatePattern='.'yyyy-MM-dd-HH
+    log4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log
+    log4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout
+    log4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
     # Change the line below to adjust ZK client logging
     log4j.logger.org.apache.zookeeper=INFO
@@ -214,47 +215,60 @@ spec:
       labels:
         app: tb-kafka
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                      - kafka
+              topologyKey: "kubernetes.io/hostname"
+      securityContext:
+        runAsUser: 799
+        runAsNonRoot: true
+        fsGroup: 799
       containers:
         - name: server
           imagePullPolicy: Always
-          image: wurstmeister/kafka:2.12-2.2.1
+          image: bitnami/kafka:3.8.1
           ports:
             - containerPort: 9092
               name: kafka-int
-          command: ["/tmp/start-node.sh"]
           readinessProbe:
             periodSeconds: 20
             tcpSocket:
               port: 9092
           livenessProbe:
-            initialDelaySeconds: 65
+            initialDelaySeconds: 25
             periodSeconds: 5
             tcpSocket:
               port: 9092
           env:
             - name: BROKER_ID_COMMAND
               value: "hostname | cut -d'-' -f3"
-            - name: KAFKA_ZOOKEEPER_CONNECT
+            - name: ALLOW_PLAINTEXT_LISTENER
+              value: "yes"
+            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
               value: "zookeeper:2181"
-            - name: KAFKA_LISTENERS
+            - name: KAFKA_CFG_LISTENERS
               value: "INSIDE://:9092"
-            - name: KAFKA_ADVERTISED_LISTENERS
+            - name: KAFKA_CFG_ADVERTISED_LISTENERS
               value: "INSIDE://:9092"
-            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+            - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
               value: "INSIDE:PLAINTEXT"
-            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+            - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
               value: "INSIDE"
-            - name: KAFKA_CREATE_TOPICS
-              value: "js_eval.requests:100:1:delete --config=retention.ms=60000 --config=segment.bytes=26214400 --config=retention.bytes=104857600,tb_transport.api.requests:30:1:delete --config=retention.ms=60000 --config=segment.bytes=26214400 --config=retention.bytes=104857600,tb_rule_engine:30:1:delete --config=retention.ms=60000 --config=segment.bytes=26214400 --config=retention.bytes=104857600"
-            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+            - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
               value: "false"
-            - name: KAFKA_LOG_RETENTION_BYTES
+            - name: KAFKA_CFG_LOG_RETENTION_BYTES
               value: "1073741824"
-            - name: KAFKA_LOG_SEGMENT_BYTES
+            - name: KAFKA_CFG_SEGMENT_BYTES
               value: "268435456"
-            - name: KAFKA_LOG_RETENTION_MS
+            - name: KAFKA_CFG_LOG_RETENTION_MS
               value: "300000"
-            - name: KAFKA_LOG_CLEANUP_POLICY
+            - name: KAFKA_CFG_LOG_CLEANUP_POLICY
               value: "delete"
             - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
               value: "1"
@@ -263,38 +277,37 @@ spec:
             - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
               value: "1"
             - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
-              value: "60000"
+              value: "30000"
             - name: KAFKA_PORT
               value: "9092"
+            - name: KAFKA_OPTS
+              value: "-Xms1G -Xmx1G -XX:+AlwaysPreTouch"
             - name: KAFKA_LOG_DIRS
-              value: "/kafka-logs/kafka"
+              value: "/kafka-data/logs"
           volumeMounts:
-            - name: logs
-              mountPath: /kafka-logs
-              readOnly: false
-            - name: start
-              mountPath: /tmp
+            - name: data-logs
+              mountPath: /kafka-data
               readOnly: false
             - name: app-logs
-              mountPath: /opt/kafka/logs
+              mountPath: /opt/bitnami/kafka/logs
               readOnly: false
-            - name: config
-              mountPath: /opt/kafka/config
+            - name: kafka-custom-config
+              mountPath: /bitnami/kafka/config
               readOnly: false
       volumes:
-        - name: start
+        - name: kafka-custom-config
           configMap:
             name: tb-kafka
             defaultMode: 0755
   volumeClaimTemplates:
     - metadata:
-        name: logs
+        name: data-logs
       spec:
         accessModes:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 10Gi
+            storage: 25Gi
     - metadata:
         name: app-logs
       spec:
@@ -302,15 +315,7 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 200Mi
-    - metadata:
-        name: config
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 50Mi
+            storage: 1000Mi
 ---
 apiVersion: v1
 kind: Service

--- a/minikube/thirdparty.yml
+++ b/minikube/thirdparty.yml
@@ -286,10 +286,8 @@ spec:
               value: "/kafka-data/logs"
             - name: KAFKA_CFG_PROCESS_ROLES
               value: "controller,broker"
-            - name: KAFKA_CFG_NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+            - name: KAFKA_NODE_ID_COMMAND
+              value: "hostname | cut -d'-' -f3"
           volumeMounts:
             - name: data-logs
               mountPath: /kafka-data

--- a/minikube/thirdparty.yml
+++ b/minikube/thirdparty.yml
@@ -223,7 +223,7 @@ spec:
                   - key: "app"
                     operator: In
                     values:
-                      - kafka
+                      - tb-kafka
               topologyKey: "kubernetes.io/hostname"
       securityContext:
         runAsUser: 799
@@ -232,7 +232,7 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: bitnami/kafka:3.8.1
+          image: bitnami/kafka:4.0.0
           ports:
             - containerPort: 9092
               name: kafka-int
@@ -241,25 +241,27 @@ spec:
             tcpSocket:
               port: 9092
           livenessProbe:
-            initialDelaySeconds: 25
+            initialDelaySeconds: 65
             periodSeconds: 5
             tcpSocket:
               port: 9092
           env:
-            - name: BROKER_ID_COMMAND
-              value: "hostname | cut -d'-' -f3"
+            - name: KAFKA_CLUSTER_ID
+              value: "A0SZ6TGET1mhlQYl49uBSQ"
             - name: ALLOW_PLAINTEXT_LISTENER
               value: "yes"
-            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
-              value: "zookeeper:2181"
             - name: KAFKA_CFG_LISTENERS
-              value: "INSIDE://:9092"
+              value: "INSIDE://:9092,CONTROLLER://:9093"
             - name: KAFKA_CFG_ADVERTISED_LISTENERS
               value: "INSIDE://:9092"
             - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
-              value: "INSIDE:PLAINTEXT"
+              value: "INSIDE:PLAINTEXT,CONTROLLER:PLAINTEXT"
             - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
               value: "INSIDE"
+            - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
+              value: "0@tb-kafka-0.tb-kafka.thingsboard.svc.cluster.local:9093"
+            - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
             - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
               value: "false"
             - name: KAFKA_CFG_LOG_RETENTION_BYTES
@@ -276,14 +278,18 @@ spec:
               value: "1"
             - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
               value: "1"
-            - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
-              value: "30000"
             - name: KAFKA_PORT
               value: "9092"
             - name: KAFKA_OPTS
               value: "-Xms1G -Xmx1G -XX:+AlwaysPreTouch"
             - name: KAFKA_LOG_DIRS
               value: "/kafka-data/logs"
+            - name: KAFKA_CFG_PROCESS_ROLES
+              value: "controller,broker"
+            - name: KAFKA_CFG_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
           volumeMounts:
             - name: data-logs
               mountPath: /kafka-data

--- a/minikube/thirdparty.yml
+++ b/minikube/thirdparty.yml
@@ -66,7 +66,7 @@ spec:
       containers:
         - name: zookeeper
           imagePullPolicy: Always
-          image: zookeeper:3.5.7
+          image: zookeeper:3.8.1
           ports:
             - containerPort: 2181
               name: client

--- a/openshift/tb-kafka-configmap.yml
+++ b/openshift/tb-kafka-configmap.yml
@@ -24,3 +24,20 @@ metadata:
 data:
   TB_QUEUE_TYPE: kafka
   TB_KAFKA_SERVERS: tb-kafka:9092
+  TB_QUEUE_KAFKA_REPLICATION_FACTOR: "1"
+  TB_KAFKA_ACKS: "1"
+
+  #Advanced section
+  TB_KAFKA_COMPRESSION_TYPE: gzip
+  TB_KAFKA_BATCH_SIZE: "65536"
+  TB_KAFKA_LINGER_MS: "5"
+  TB_QUEUE_KAFKA_MAX_POLL_RECORDS: "1024"
+  #retention 24 hours or 512 mb
+  TB_QUEUE_KAFKA_RE_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:1;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_CORE_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:1;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_TA_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_NOTIFICATIONS_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:1;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_JE_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_OTA_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_VC_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"
+  TB_QUEUE_KAFKA_INTEGRATION_TOPIC_PROPERTIES: "retention.ms:86400000;segment.bytes:26214400;retention.bytes:536870912;partitions:10;min.insync.replicas:1"

--- a/openshift/thirdparty.yml
+++ b/openshift/thirdparty.yml
@@ -235,29 +235,49 @@ spec:
           image: bitnami/kafka:4.0.0
           ports:
             - containerPort: 9092
-              name: kafka-int
-          readinessProbe:
-            periodSeconds: 20
+              name: client
+            - containerPort: 9093
+              name: controller
+          startupProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 15
+            successThreshold: 1
             tcpSocket:
-              port: 9092
+              port: "controller"
           livenessProbe:
-            initialDelaySeconds: 65
-            periodSeconds: 5
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            exec:
+              command:
+                - pgrep
+                - -f
+                - kafka
+          readinessProbe:
+            initialDelaySeconds: 15
+            failureThreshold: 10
+            timeoutSeconds: 5
+            periodSeconds: 15
+            successThreshold: 1
             tcpSocket:
-              port: 9092
+              port: "controller"
           env:
             - name: KAFKA_CLUSTER_ID
               value: "A0SZ6TGET1mhlQYl49uBSQ"
             - name: ALLOW_PLAINTEXT_LISTENER
               value: "yes"
             - name: KAFKA_CFG_LISTENERS
-              value: "INSIDE://:9092,CONTROLLER://:9093"
+              value: "PLAINTEXT://:9092,CONTROLLER://:9093"
             - name: KAFKA_CFG_ADVERTISED_LISTENERS
-              value: "INSIDE://:9092"
+              value: "PLAINTEXT://:9092"
             - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
-              value: "INSIDE:PLAINTEXT,CONTROLLER:PLAINTEXT"
+              value: "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"
             - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
-              value: "INSIDE"
+              value: "PLAINTEXT"
             - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
               value: "0@tb-kafka-0.tb-kafka.thingsboard.svc.cluster.local:9093"
             - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES

--- a/openshift/thirdparty.yml
+++ b/openshift/thirdparty.yml
@@ -169,22 +169,23 @@ metadata:
   name: tb-kafka
   namespace: thingsboard
 data:
-  start-node.sh: |
-    #!/bin/sh
-    cp /tmp/tools-log4j.properties /opt/kafka/config/tools-log4j.properties
-    cp /tmp/log4j.properties /opt/kafka/config/log4j.properties
-    /usr/bin/start-kafka.sh
   tools-log4j.properties: |+
     log4j.rootLogger=WARN, stdout
     log4j.appender.stdout=org.apache.log4j.ConsoleAppender
     log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
     log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
   log4j.properties: |+
-    log4j.rootLogger=INFO, stdout
+    log4j.rootLogger=INFO, stdout, kafkaAppender
 
     log4j.appender.stdout=org.apache.log4j.ConsoleAppender
     log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
     log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+    log4j.appender.kafkaAppender=org.apache.log4j.DailyRollingFileAppender
+    log4j.appender.kafkaAppender.DatePattern='.'yyyy-MM-dd-HH
+    log4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log
+    log4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout
+    log4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
     # Change the line below to adjust ZK client logging
     log4j.logger.org.apache.zookeeper=INFO
@@ -204,6 +205,7 @@ metadata:
   namespace: thingsboard
 spec:
   serviceName: "tb-kafka"
+  replicas: 1
   podManagementPolicy: Parallel
   selector:
     matchLabels:
@@ -213,14 +215,27 @@ spec:
       labels:
         app: tb-kafka
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                      - kafka
+              topologyKey: "kubernetes.io/hostname"
+      securityContext:
+        runAsUser: 799
+        runAsNonRoot: true
+        fsGroup: 799
       containers:
         - name: server
           imagePullPolicy: Always
-          image: wurstmeister/kafka:2.12-2.2.1
+          image: bitnami/kafka:3.8.1
           ports:
             - containerPort: 9092
               name: kafka-int
-          command: ["/tmp/start-node.sh"]
           readinessProbe:
             periodSeconds: 20
             tcpSocket:
@@ -233,27 +248,27 @@ spec:
           env:
             - name: BROKER_ID_COMMAND
               value: "hostname | cut -d'-' -f3"
-            - name: KAFKA_ZOOKEEPER_CONNECT
+            - name: ALLOW_PLAINTEXT_LISTENER
+              value: "yes"
+            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
               value: "zookeeper:2181"
-            - name: KAFKA_LISTENERS
+            - name: KAFKA_CFG_LISTENERS
               value: "INSIDE://:9092"
-            - name: KAFKA_ADVERTISED_LISTENERS
+            - name: KAFKA_CFG_ADVERTISED_LISTENERS
               value: "INSIDE://:9092"
-            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+            - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
               value: "INSIDE:PLAINTEXT"
-            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+            - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
               value: "INSIDE"
-            - name: KAFKA_CREATE_TOPICS
-              value: "js_eval.requests:100:1:delete --config=retention.ms=60000 --config=segment.bytes=26214400 --config=retention.bytes=104857600,tb_transport.api.requests:30:1:delete --config=retention.ms=60000 --config=segment.bytes=26214400 --config=retention.bytes=104857600,tb_rule_engine:30:1:delete --config=retention.ms=60000 --config=segment.bytes=26214400 --config=retention.bytes=104857600"
-            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+            - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
               value: "false"
-            - name: KAFKA_LOG_RETENTION_BYTES
+            - name: KAFKA_CFG_LOG_RETENTION_BYTES
               value: "1073741824"
-            - name: KAFKA_LOG_SEGMENT_BYTES
+            - name: KAFKA_CFG_SEGMENT_BYTES
               value: "268435456"
-            - name: KAFKA_LOG_RETENTION_MS
+            - name: KAFKA_CFG_LOG_RETENTION_MS
               value: "300000"
-            - name: KAFKA_LOG_CLEANUP_POLICY
+            - name: KAFKA_CFG_LOG_CLEANUP_POLICY
               value: "delete"
             - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
               value: "1"
@@ -262,38 +277,37 @@ spec:
             - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
               value: "1"
             - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
-              value: "3000"
+              value: "30000"
             - name: KAFKA_PORT
               value: "9092"
+            - name: KAFKA_OPTS
+              value: "-Xms1G -Xmx1G -XX:+AlwaysPreTouch"
             - name: KAFKA_LOG_DIRS
-              value: "/kafka-logs/kafka"
+              value: "/kafka-data/logs"
           volumeMounts:
-            - name: logs
-              mountPath: /kafka-logs
-              readOnly: false
-            - name: start
-              mountPath: /tmp
+            - name: data-logs
+              mountPath: /kafka-data
               readOnly: false
             - name: app-logs
-              mountPath: /opt/kafka/logs
+              mountPath: /opt/bitnami/kafka/logs
               readOnly: false
-            - name: config
-              mountPath: /opt/kafka/config
+            - name: kafka-custom-config
+              mountPath: /bitnami/kafka/config
               readOnly: false
       volumes:
-        - name: start
+        - name: kafka-custom-config
           configMap:
             name: tb-kafka
             defaultMode: 0755
   volumeClaimTemplates:
     - metadata:
-        name: logs
+        name: data-logs
       spec:
         accessModes:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 10Gi
+            storage: 25Gi
     - metadata:
         name: app-logs
       spec:
@@ -301,15 +315,7 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 200Mi
-    - metadata:
-        name: config
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 50Mi
+            storage: 1000Mi
 ---
 apiVersion: v1
 kind: Service

--- a/openshift/thirdparty.yml
+++ b/openshift/thirdparty.yml
@@ -286,10 +286,8 @@ spec:
               value: "/kafka-data/logs"
             - name: KAFKA_CFG_PROCESS_ROLES
               value: "controller,broker"
-            - name: KAFKA_CFG_NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+            - name: KAFKA_NODE_ID_COMMAND
+              value: "hostname | cut -d'-' -f3"
           volumeMounts:
             - name: data-logs
               mountPath: /kafka-data

--- a/openshift/thirdparty.yml
+++ b/openshift/thirdparty.yml
@@ -223,7 +223,7 @@ spec:
                   - key: "app"
                     operator: In
                     values:
-                      - kafka
+                      - tb-kafka
               topologyKey: "kubernetes.io/hostname"
       securityContext:
         runAsUser: 799
@@ -232,7 +232,7 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: bitnami/kafka:3.8.1
+          image: bitnami/kafka:4.0.0
           ports:
             - containerPort: 9092
               name: kafka-int
@@ -241,25 +241,27 @@ spec:
             tcpSocket:
               port: 9092
           livenessProbe:
-            initialDelaySeconds: 25
+            initialDelaySeconds: 65
             periodSeconds: 5
             tcpSocket:
               port: 9092
           env:
-            - name: BROKER_ID_COMMAND
-              value: "hostname | cut -d'-' -f3"
+            - name: KAFKA_CLUSTER_ID
+              value: "A0SZ6TGET1mhlQYl49uBSQ"
             - name: ALLOW_PLAINTEXT_LISTENER
               value: "yes"
-            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
-              value: "zookeeper:2181"
             - name: KAFKA_CFG_LISTENERS
-              value: "INSIDE://:9092"
+              value: "INSIDE://:9092,CONTROLLER://:9093"
             - name: KAFKA_CFG_ADVERTISED_LISTENERS
               value: "INSIDE://:9092"
             - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
-              value: "INSIDE:PLAINTEXT"
+              value: "INSIDE:PLAINTEXT,CONTROLLER:PLAINTEXT"
             - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
               value: "INSIDE"
+            - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
+              value: "0@tb-kafka-0.tb-kafka.thingsboard.svc.cluster.local:9093"
+            - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
             - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
               value: "false"
             - name: KAFKA_CFG_LOG_RETENTION_BYTES
@@ -276,14 +278,18 @@ spec:
               value: "1"
             - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
               value: "1"
-            - name: KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS
-              value: "30000"
             - name: KAFKA_PORT
               value: "9092"
             - name: KAFKA_OPTS
               value: "-Xms1G -Xmx1G -XX:+AlwaysPreTouch"
             - name: KAFKA_LOG_DIRS
               value: "/kafka-data/logs"
+            - name: KAFKA_CFG_PROCESS_ROLES
+              value: "controller,broker"
+            - name: KAFKA_CFG_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
           volumeMounts:
             - name: data-logs
               mountPath: /kafka-data

--- a/openshift/thirdparty.yml
+++ b/openshift/thirdparty.yml
@@ -66,7 +66,7 @@ spec:
       containers:
         - name: zookeeper
           imagePullPolicy: Always
-          image: zookeeper:3.5.7
+          image: zookeeper:3.8.1
           ports:
             - containerPort: 2181
               name: client


### PR DESCRIPTION
Tested on AWS and minikube.
AWS:
![image](https://github.com/user-attachments/assets/f5f7fe93-f77d-4eff-af3c-30062c7030db)
![image](https://github.com/user-attachments/assets/dc071fa1-9254-4fde-a0e1-7512099de832)
TB log
```
2025-05-13 12:28:05,964 [kafka-consumer-stats-16-thread-1] INFO  org.apache.kafka.clients.Metadata - [Consumer clientId=consumer-stats-loader-client, groupId=consumer-stats-loader-client-group] Cluster ID: A0SZ6TGET1mhlQYl49uBSQ
```
Minikube:
![image](https://github.com/user-attachments/assets/ee14f8bd-8a22-4403-ae6b-d7b56e1d16fa)
![image](https://github.com/user-attachments/assets/9ecfe61e-be2d-4403-9bee-3acbbc01dec4)
TB log
```
2025-05-13 12:49:28,211 [kafka-consumer-stats-5-thread-1] INFO  org.apache.kafka.clients.Metadata - [Consumer clientId=consumer-stats-loader-client, groupId=consumer-stats-loader-client-group] Cluster ID: A0SZ6TGET1mhlQYl49uBSQ
```
