### PR TITLE
Improve resource and storage configuration for Valkey

### DIFF
--- a/aws/microservices/tb-cache-configmap.yml
+++ b/aws/microservices/tb-cache-configmap.yml
@@ -27,3 +27,4 @@ data:
   REDIS_HOST: YOUR_VALKEY_ENDPOINT_URL_WITHOUT_PORT
   #VALKEY POOL CONFIG
   REDIS_USE_DEFAULT_POOL_CONFIG: "false"
+  VALKEY_EXTRA_FLAGS: "--maxmemory 500mb --maxmemory-policy allkeys-lru"

--- a/azure/microservices/tb-cache-configmap.yml
+++ b/azure/microservices/tb-cache-configmap.yml
@@ -29,3 +29,4 @@ data:
   #VALKEY POOL CONFIG
   REDIS_USE_DEFAULT_POOL_CONFIG: "false"
   VALKEY_EXTRA_FLAGS: "--maxmemory 500mb --maxmemory-policy allkeys-lru"
+  

--- a/azure/microservices/tb-cache-configmap.yml
+++ b/azure/microservices/tb-cache-configmap.yml
@@ -28,3 +28,4 @@ data:
   REDIS_PASSWORD: YOUR_VALKEY_PASSWORD
   #VALKEY POOL CONFIG
   REDIS_USE_DEFAULT_POOL_CONFIG: "false"
+  VALKEY_EXTRA_FLAGS: "--maxmemory 500mb --maxmemory-policy allkeys-lru"

--- a/gcp/microservices/k8s-install-tb.sh
+++ b/gcp/microservices/k8s-install-tb.sh
@@ -27,7 +27,7 @@ function installTb() {
 
     kubectl rollout status statefulset/zookeeper
     kubectl rollout status statefulset/tb-kafka
-    kubectl rollout status deployment/tb-valkey
+    kubectl rollout status statefulset/tb-valkey
     kubectl apply -f database-setup.yml &&
     kubectl wait --for=condition=Ready pod/tb-db-setup --timeout=120s &&
     kubectl exec tb-db-setup -- sh -c 'export INSTALL_TB=true; export LOAD_DEMO='"$loadDemo"'; start-tb-node.sh; touch /tmp/install-finished;'

--- a/gcp/microservices/thirdparty.yml
+++ b/gcp/microservices/thirdparty.yml
@@ -362,11 +362,11 @@ spec:
             - containerPort: 6379
           resources:
             limits:
-              cpu: "300m"
-              memory: 1200Mi
+              cpu: "500m"
+              memory: 400Mi
             requests:
-              cpu: "300m"
-              memory: 1200Mi
+              cpu: "100m"
+              memory: 400Mi
           readinessProbe:
             periodSeconds: 5
             tcpSocket:

--- a/gcp/microservices/thirdparty.yml
+++ b/gcp/microservices/thirdparty.yml
@@ -378,6 +378,8 @@ spec:
           env:
             - name: ALLOW_EMPTY_PASSWORD
               value: "yes"
+            - name: VALKEY_EXTRA_FLAGS
+              value: "--maxmemory 500mb --maxmemory-policy allkeys-lru"
           volumeMounts:
             - mountPath: /data
               name: valkey-data

--- a/gcp/microservices/thirdparty.yml
+++ b/gcp/microservices/thirdparty.yml
@@ -339,11 +339,13 @@ spec:
   clusterIP: None
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: tb-valkey
   namespace: thingsboard
 spec:
+  serviceName: "tb-valkey"
+  replicas: 1
   selector:
     matchLabels:
       app: tb-valkey
@@ -383,10 +385,15 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: valkey-data
-      volumes:
-        - name: valkey-data
-          emptyDir: {}
-      restartPolicy: Always
+  volumeClaimTemplates:
+    - metadata:
+        name: valkey-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
 ---
 apiVersion: v1
 kind: Service

--- a/minikube/k8s-install-tb.sh
+++ b/minikube/k8s-install-tb.sh
@@ -27,7 +27,7 @@ function installTb() {
 
     kubectl rollout status statefulset/zookeeper
     kubectl rollout status statefulset/tb-kafka
-    kubectl rollout status deployment/tb-valkey
+    kubectl rollout status statefulset/tb-valkey
     kubectl apply -f database-setup.yml &&
     kubectl wait --for=condition=Ready pod/tb-db-setup --timeout=120s &&
     kubectl exec tb-db-setup -- sh -c 'export INSTALL_TB=true; export LOAD_DEMO='"$loadDemo"'; start-tb-node.sh; touch /tmp/install-finished;'

--- a/minikube/thirdparty.yml
+++ b/minikube/thirdparty.yml
@@ -315,11 +315,13 @@ spec:
   clusterIP: None
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: tb-valkey
   namespace: thingsboard
 spec:
+  serviceName: "tb-valkey"
+  replicas: 1
   selector:
     matchLabels:
       app: tb-valkey
@@ -357,10 +359,15 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: valkey-data
-      volumes:
-        - name: valkey-data
-          emptyDir: {}
-      restartPolicy: Always
+  volumeClaimTemplates:
+    - metadata:
+        name: valkey-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
 ---
 apiVersion: v1
 kind: Service

--- a/minikube/thirdparty.yml
+++ b/minikube/thirdparty.yml
@@ -345,6 +345,8 @@ spec:
           env:
             - name: ALLOW_EMPTY_PASSWORD
               value: "yes"
+            - name: VALKEY_EXTRA_FLAGS
+              value: "--maxmemory 500mb --maxmemory-policy allkeys-lru"
           volumeMounts:
             - mountPath: /data
               name: valkey-data

--- a/minikube/thirdparty.yml
+++ b/minikube/thirdparty.yml
@@ -332,6 +332,13 @@ spec:
         - name: server
           imagePullPolicy: Always
           image: bitnami/valkey:8.0
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "400Mi"
+            requests:
+              cpu: "100m"
+              memory: "400Mi"
           ports:
             - containerPort: 6379
           readinessProbe:

--- a/openshift/k8s-install-tb.sh
+++ b/openshift/k8s-install-tb.sh
@@ -27,7 +27,7 @@ function installTb() {
 
     kubectl rollout status statefulset/zookeeper
     kubectl rollout status statefulset/tb-kafka
-    kubectl rollout status deployment/tb-valkey
+    kubectl rollout status statefulset/tb-valkey
     kubectl apply -f database-setup.yml &&
     kubectl wait --for=condition=Ready pod/tb-db-setup --timeout=120s &&
     kubectl exec tb-db-setup -- sh -c 'export INSTALL_TB=true; export LOAD_DEMO='"$loadDemo"'; start-tb-node.sh; touch /tmp/install-finished;'

--- a/openshift/thirdparty.yml
+++ b/openshift/thirdparty.yml
@@ -330,6 +330,13 @@ spec:
         - name: server
           imagePullPolicy: Always
           image: bitnami/valkey:8.0
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "400Mi"
+            requests:
+              cpu: "100m"
+              memory: "400Mi"
           ports:
             - containerPort: 6379
           readinessProbe:

--- a/openshift/thirdparty.yml
+++ b/openshift/thirdparty.yml
@@ -313,11 +313,13 @@ spec:
   clusterIP: None
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: tb-valkey
   namespace: thingsboard
 spec:
+  serviceName: "tb-valkey"
+  replicas: 1
   selector:
     matchLabels:
       app: tb-valkey
@@ -355,10 +357,15 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: valkey-data
-      volumes:
-        - name: valkey-data
-          emptyDir: {}
-      restartPolicy: Always
+  volumeClaimTemplates:
+    - metadata:
+        name: valkey-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
 ---
 apiVersion: v1
 kind: Service

--- a/openshift/thirdparty.yml
+++ b/openshift/thirdparty.yml
@@ -343,6 +343,8 @@ spec:
           env:
             - name: ALLOW_EMPTY_PASSWORD
               value: "yes"
+            - name: VALKEY_EXTRA_FLAGS
+              value: "--maxmemory 500mb --maxmemory-policy allkeys-lru"
           volumeMounts:
             - mountPath: /data
               name: valkey-data


### PR DESCRIPTION
## Description

Improves the resource and storage configuration for the Valkey deployment.

## Chages

* **Resource Limits and Requests:**
    * Increased CPU limits from `300m` to `500m`.
    * Decreased CPU requests from `300m` to `100m`.
    * Decreased Memory limits from `1200Mi` to `400Mi`.
    * Decreased Memory requests from `1200Mi` to `400Mi`.

* **Storage Configuration:**
    * Added persistence storage with default size `1Gi`.

* **Relevant Valkey Configuration changes:**
    * Added `memory-policy allkeys-lru`.
    * Set `maxmemory 500mb`.
    * Adjust Valkey deployment manifest.

## Testing

* **Local Testing:** Deployed ThingsBoard locally using Kubernetes with the updated Valkey configuration.
    * All functionalities are working as expected, and Valkey demonstrates stable operation with the allocated resources.
    * No resource-related errors or critical performance warnings related to Valkey were observed.
    * **Log Files:**
        * [thingsboard-installation.log](https://github.com/user-attachments/files/20819362/thingsboard-installation.log)
        * [status-pods.log](https://github.com/user-attachments/files/20819363/status-pods.log)
        * [pvc.log](https://github.com/user-attachments/files/20819364/pvc.log)


