### PR TITLE
Image migration from bitnami to bitnamilegacy

### DIFF
--- a/aws/microservices/tb-kafka.yml
+++ b/aws/microservices/tb-kafka.yml
@@ -53,7 +53,7 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: bitnami/kafka:4.0.0
+          image: bitnamilegacy/kafka:4.0.0
           ports:
             - containerPort: 9092
               name: client

--- a/aws/microservices/tb-valkey.yml
+++ b/aws/microservices/tb-valkey.yml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: bitnami/valkey:8.0
+          image: bitnamilegacy/valkey:8.0
           ports:
             - containerPort: 6379
           resources:

--- a/azure/microservices/thirdparty.yml
+++ b/azure/microservices/thirdparty.yml
@@ -204,7 +204,7 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: bitnami/kafka:4.0.0
+          image: bitnamilegacy/kafka:4.0.0
           ports:
             - containerPort: 9092
               name: client
@@ -353,7 +353,7 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: bitnami/valkey:8.0
+          image: bitnamilegacy/valkey:8.0
           ports:
             - containerPort: 6379
           resources:

--- a/gcp/microservices/thirdparty.yml
+++ b/gcp/microservices/thirdparty.yml
@@ -208,7 +208,7 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: bitnami/kafka:4.0.0
+          image: bitnamilegacy/kafka:4.0.0
           ports:
             - containerPort: 9092
               name: client
@@ -359,7 +359,7 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: bitnami/valkey:8.0
+          image: bitnamilegacy/valkey:8.0
           ports:
             - containerPort: 6379
           resources:

--- a/minikube/thirdparty.yml
+++ b/minikube/thirdparty.yml
@@ -197,7 +197,7 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: bitnami/kafka:4.0.0
+          image: bitnamilegacy/kafka:4.0.0
           ports:
             - containerPort: 9092
               name: client
@@ -333,7 +333,7 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: bitnami/valkey:8.0
+          image: bitnamilegacy/valkey:8.0
           resources:
             limits:
               cpu: "500m"

--- a/openshift/thirdparty.yml
+++ b/openshift/thirdparty.yml
@@ -197,7 +197,7 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: bitnami/kafka:4.0.0
+          image: bitnamilegacy/kafka:4.0.0
           ports:
             - containerPort: 9092
               name: client
@@ -331,7 +331,7 @@ spec:
       containers:
         - name: server
           imagePullPolicy: Always
-          image: bitnami/valkey:8.0
+          image: bitnamilegacy/valkey:8.0
           resources:
             limits:
               cpu: "500m"


### PR DESCRIPTION
Modify the manifests to pull from the bitnamilegacy repository.

* [bitnamilegacy/kafka/4.0.0](https://hub.docker.com/layers/bitnamilegacy/kafka/4.0.0/images/sha256-c5bc3cfe2200fe0c1a34e6e6ffd3096da502bce90d98b7da4548032e74c92984)
* [bitnamilegacy/valkey/8.0](https://hub.docker.com/layers/bitnamilegacy/valkey/8.0/images/sha256-382717bca25bec223f4ce1861fe6269cbe39b77e161b366b47a9fbca346bd50b)